### PR TITLE
Add Nested Scope to the controllers reference doc

### DIFF
--- a/docs/reference/controllers.md
+++ b/docs/reference/controllers.md
@@ -61,7 +61,7 @@ For example, the `<div>` and `<h1>` below are part of the controller's scope, bu
 
 ## Nested Scopes
 
-When controllers are nested, they're aware of _only_ their own scope and not the scope of any controllers nested within them.
+When nested, each controller is only aware of its own scope excluding the scope of any controllers nested within.
 
 For example, the `#parent` controller below is only aware of the `list.item` targets directly within its scope, but not any targets of the `#child` controller.
 

--- a/docs/reference/controllers.md
+++ b/docs/reference/controllers.md
@@ -59,6 +59,25 @@ For example, the `<div>` and `<h1>` below are part of the controller's scope, bu
 </main>
 ```
 
+## Nested Scopes
+
+When controllers are nested, they're aware of _only_ their own scope and not the scope of any controllers nested within them.
+
+For example, the `#parent` controller below is only aware of the `list.item` targets directly within its scope, but not any targets of the `#child` controller.
+
+```html
+<ul id="parent" data-controller="list">
+  <li data-target="list.item">One</li>
+  <li data-target="list.item">Two</li>
+  <li>
+    <ul id="child" data-controller="list">
+      <li data-target="list.item">I am</li>
+      <li data-target="list.item">a nested list</li>
+    </ul>
+  </li>
+</ul>
+```
+
 ## Multiple Controllers
 
 The `data-controller` attribute's value is a space-separated list of identifiers:


### PR DESCRIPTION
Provides a short description and example of how scope behaves for nested controllers.

I was reading through the docs and some examples getting a feel for the framework in general and noticed the nested scope behavior. Then I saw [this discourse post](https://discourse.stimulusjs.org/t/are-recursive-controllers-explicitly-supported/421).

I think having even a brief description in the docs will especially help out devs new to the framework. 