### PR TITLE
Add a convenientce method for dispatching DOM events inside a controller

### DIFF
--- a/packages/@stimulus/core/src/context.ts
+++ b/packages/@stimulus/core/src/context.ts
@@ -70,6 +70,13 @@ export class Context implements ErrorHandler {
     return this.element.parentElement
   }
 
+  dispatch(eventName: String, { target = this.element, detail = {}, bubbles = true, cancelable = true } = {}) {
+    const type = `${this.identifier}:${eventName}`
+    const event = new CustomEvent(type, { detail, bubbles, cancelable })
+    target.dispatchEvent(event)
+    return event
+  }
+
   // Error handling
 
   handleError(error: Error, message: string, detail: object = {}) {

--- a/packages/@stimulus/core/src/context.ts
+++ b/packages/@stimulus/core/src/context.ts
@@ -70,8 +70,8 @@ export class Context implements ErrorHandler {
     return this.element.parentElement
   }
 
-  dispatch(eventName: String, { target = this.element, detail = {}, bubbles = true, cancelable = true } = {}) {
-    const type = `${this.identifier}:${eventName}`
+  dispatch(eventName: String, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true } = {}) {
+    const type = prefix ? `${prefix}:${eventName}` : eventName
     const event = new CustomEvent(type, { detail, bubbles, cancelable })
     target.dispatchEvent(event)
     return event


### PR DESCRIPTION
I came across this method while reading through the javascript code of [Hey](https://hey.com), and have implemented it, along with the globally accessible `ApplicationController`, into a couple of projects already.

I'm only responsible for compiling this PR, credit goes to the folks behind Hey 💯

1. It establishes an adequate event naming convention.
2. It encapsulates the steps you'd have to take to define and emit a custom event into a single `this.dispatch` call.

Here's an simplified e-shop example:
```javascript
import { Controller } from 'stimulus'

// cart_controller.js
export default class extends Controller {
  updateCart() {
    // Does stuff...
    this.dispatch('updated', { itemsCount })
  }
}

// cart_badge_controller.js
export default class extends Controller {
  static targets = [ 'counter' ]

  initialize() {
    document.addEventListener('cart:updated', this.refreshCounter.bind(this))
  }

  // Actions
  refreshCounter({ detail: { itemsCount } }) {
    this.counterTarget.innerText = itemsCount
  }
}
```