### PR TITLE
Specify wrapping data target in controller div

### DIFF
--- a/docs/handbook/03_building_something_real.md
+++ b/docs/handbook/03_building_something_real.md
@@ -51,7 +51,7 @@ Then add `data-controller="clipboard"` to the outer `<div>`. Any time this attri
 
 ## Defining the Target
 
-We'll need a reference to the text field so we can select its contents before invoking the clipboard API. Add `data-target="clipboard.source"` to the text field:
+We'll need a reference to the text field so we can select its contents before invoking the clipboard API. This data-target must be inside the  <div data-controller defined in the last step.  Add `data-target="clipboard.source"` to the text field:
 
 ```html
   PIN: <input data-target="clipboard.source" type="text" value="1234" readonly>


### PR DESCRIPTION
Specify in the handbook that stimulus looks for data-targets defined only inside the controller div, not anywhere in the view.