### PR TITLE
Add: Rails example for installing

### DIFF
--- a/docs/handbook/06_installing_stimulus.md
+++ b/docs/handbook/06_installing_stimulus.md
@@ -25,6 +25,17 @@ const application = Application.start()
 const context = require.context("./controllers", true, /\.js$/)
 application.load(definitionsFromContext(context))
 ```
+### Integrating Stimulus with Rails (via Webpacker)
+
+If you are running a Rails 6+ application, getting a working example of Stimulus as simple as hammering: 
+
+`bundle exec rails webpacker:install:stimulus`
+
+This [does the following](https://github.com/rails/webpacker/blob/master/lib/install/stimulus.rb):
+
+* Appends some set up code to your `./app/javascript/packs/application.js` file.
+* Creates a stimulus controller directory in your `Webpacker.config.source_path` (i.e. `./app/javascript/packs/controllers`) with an example controller.
+* Installs stimulus via yarn.
 
 ### Controller Filenames Map to Identifiers
 

--- a/docs/handbook/06_installing_stimulus.md
+++ b/docs/handbook/06_installing_stimulus.md
@@ -25,17 +25,9 @@ const application = Application.start()
 const context = require.context("./controllers", true, /\.js$/)
 application.load(definitionsFromContext(context))
 ```
-### Integrating Stimulus with Rails (via Webpacker)
+### Webpacker Gem
 
-If you are running a Rails 6+ application, getting a working example of Stimulus as simple as hammering: 
-
-`bundle exec rails webpacker:install:stimulus`
-
-This [does the following](https://github.com/rails/webpacker/blob/master/lib/install/stimulus.rb):
-
-* Appends some set up code to your `./app/javascript/packs/application.js` file.
-* Creates a stimulus controller directory in your `Webpacker.config.source_path` (i.e. `./app/javascript/packs/controllers`) with an example controller.
-* Installs stimulus via yarn.
+It integrates well with the webpacker gem (if you are using it). Please refer to the (Stimulus instructions in that project)[https://github.com/rails/webpacker].
 
 ### Controller Filenames Map to Identifiers
 


### PR DESCRIPTION
## Why this PR?

A subset of folks who use stimulus also use Rails. But how can one easily integrate the two? This minor addition obviates the need for extra searching via stack overflow etc. 

I hope it is helpful.