### PR TITLE
Add CSS escaping for query selectors

### DIFF
--- a/packages/@stimulus/core/src/scope.ts
+++ b/packages/@stimulus/core/src/scope.ts
@@ -40,7 +40,7 @@ export class Scope {
   }
 
   private queryElements(selector: string): Element[] {
-    return Array.from(this.element.querySelectorAll(selector))
+    return Array.from(this.element.querySelectorAll(CSS.escape(selector)))
   }
 
   private get controllerSelector(): string {

--- a/packages/@stimulus/polyfills/index.js
+++ b/packages/@stimulus/polyfills/index.js
@@ -9,6 +9,7 @@ import "core-js/es/string/starts-with"
 import "element-closest"
 import "mutation-observer-inner-html-shim"
 import "eventlistener-polyfill"
+import "css.escape"
 
 if (typeof SVGElement.prototype.contains != "function") {
   SVGElement.prototype.contains = function(node) {

--- a/packages/@stimulus/polyfills/package.json
+++ b/packages/@stimulus/polyfills/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "core-js": "^3.4.0",
+    "css.escape": "^1.5.1",
     "element-closest": "^2.0.2",
     "eventlistener-polyfill": "^1.0.5",
     "mutation-observer-inner-html-shim": "^1.0.0"


### PR DESCRIPTION
Hi! First PR on Stimulus, hopefully not the last :) !

In the context of [Symfony UX](https://symfony.com/blog/new-in-symfony-the-ux-initiative-a-new-javascript-ecosystem-for-symfony), we rely on the `@` character to note a controller coming from the vendors (for instance:  `@symfony/ux-chartjs/chart`).

In Stimulus 1, this notation was fine because targets were defined using the legacy notation. With the new notation, the `@` and `/` raise issues (which makes sense).

I'm working on migrating away from `/` to `--`, as is natively done by Stimulus Webpack helpers. However, `@` is fine in HTML attribute names, and I'd like to keep it as it would allow us to detect controllers coming from vendors vs the ones coming from the app.

For the moment, the main problem I see is that Stimulus doesn't escape CSS selectors when using them, thus this PR. CSS.escape is supported by many majors browsers (https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape) and a reliable polyfill exists (https://github.com/mathiasbynens/CSS.escape), which we could add as a peerDependency if you find it useful.

I'm not sure how to test this for now, if you have any tip I'd be happy to learn!