### PR TITLE
Introduce a Debug mode

### DIFF
--- a/packages/@stimulus/core/src/application.ts
+++ b/packages/@stimulus/core/src/application.ts
@@ -32,14 +32,14 @@ export class Application implements ErrorHandler {
     this.logDebugActivity("application", "starting")
     this.dispatcher.start()
     this.router.start()
-    this.logDebugActivity("application", "started")
+    this.logDebugActivity("application", "start")
   }
 
   stop() {
     this.logDebugActivity("application", "stopping")
     this.dispatcher.stop()
     this.router.stop()
-    this.logDebugActivity("application", "stoped")
+    this.logDebugActivity("application", "stop")
   }
 
   register(identifier: string, controllerConstructor: ControllerConstructor) {

--- a/packages/@stimulus/core/src/application.ts
+++ b/packages/@stimulus/core/src/application.ts
@@ -36,7 +36,7 @@ export class Application implements ErrorHandler {
   }
 
   stop() {
-    this.logDebugActivity("application", "stoping")
+    this.logDebugActivity("application", "stopping")
     this.dispatcher.stop()
     this.router.stop()
     this.logDebugActivity("application", "stoped")

--- a/packages/@stimulus/core/src/application.ts
+++ b/packages/@stimulus/core/src/application.ts
@@ -12,6 +12,7 @@ export class Application implements ErrorHandler {
   readonly dispatcher: Dispatcher
   readonly router: Router
   logger: Logger = console
+  debug: boolean = false
 
   static start(element?: Element, schema?: Schema): Application {
     const application = new Application(element, schema)
@@ -28,13 +29,17 @@ export class Application implements ErrorHandler {
 
   async start() {
     await domReady()
+    this.logDebugActivity("application", "starting")
     this.dispatcher.start()
     this.router.start()
+    this.logDebugActivity("application", "started")
   }
 
   stop() {
+    this.logDebugActivity("application", "stoping")
     this.dispatcher.stop()
     this.router.stop()
+    this.logDebugActivity("application", "stoped")
   }
 
   register(identifier: string, controllerConstructor: ControllerConstructor) {
@@ -70,6 +75,24 @@ export class Application implements ErrorHandler {
 
   handleError(error: Error, message: string, detail: object) {
     this.logger.error(`%s\n\n%o\n\n%o`, message, error, detail)
+  }
+
+  // Debug logging
+
+  logDebugActivity = (identifier: string, functionName: string, detail: object = {}): void => {
+    if (this.debug) {
+      this.logFormattedMessage(identifier, functionName, detail)
+    }
+  }
+
+  private logFormattedMessage(identifier: string, functionName: string, detail: object = {}) {
+    const darkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+    const color = darkMode ? "#ffe000" : "#5D2F85"
+    detail = Object.assign({ application: this }, detail)
+
+    this.logger.groupCollapsed(`%c${identifier}%c #${functionName}`, `color: ${color}`, 'color: unset')
+    this.logger.log("details:", { ...detail })
+    this.logger.groupEnd()
   }
 }
 

--- a/packages/@stimulus/core/src/binding.ts
+++ b/packages/@stimulus/core/src/binding.ts
@@ -47,8 +47,10 @@ export class Binding {
   }
 
   private invokeWithEvent(event: Event) {
+    const { target, currentTarget } = event
     try {
       this.method.call(this.controller, event)
+      this.context.logDebugActivity(this.methodName, { event, target, currentTarget, action: this.methodName })
     } catch (error) {
       const { identifier, controller, element, index } = this
       const detail = { identifier, controller, element, index, event }

--- a/packages/@stimulus/core/src/context.ts
+++ b/packages/@stimulus/core/src/context.ts
@@ -24,6 +24,7 @@ export class Context implements ErrorHandler {
 
     try {
       this.controller.initialize()
+      this.logDebugActivity("initialize")
     } catch (error) {
       this.handleError(error, "initializing controller")
     }
@@ -35,6 +36,7 @@ export class Context implements ErrorHandler {
 
     try {
       this.controller.connect()
+      this.logDebugActivity("connect")
     } catch (error) {
       this.handleError(error, "connecting controller")
     }
@@ -43,6 +45,7 @@ export class Context implements ErrorHandler {
   disconnect() {
     try {
       this.controller.disconnect()
+      this.logDebugActivity("disconnect")
     } catch (error) {
       this.handleError(error, "disconnecting controller")
     }
@@ -81,5 +84,13 @@ export class Context implements ErrorHandler {
     const { identifier, controller, element } = this
     detail = Object.assign({ identifier, controller, element }, detail)
     this.application.handleError(error, `Error ${message}`, detail)
+  }
+
+  // Debug logging
+
+  logDebugActivity = (functionName: string, detail: object = {}): void => {
+    const { identifier, controller, element } = this
+    detail = Object.assign({ identifier, controller, element }, detail)
+    this.application.logDebugActivity(this.identifier, functionName, detail)
   }
 }

--- a/packages/@stimulus/core/src/logger.ts
+++ b/packages/@stimulus/core/src/logger.ts
@@ -2,4 +2,6 @@ export interface Logger {
   log(message: string, ...args: any[]): void
   warn(message: string, ...args: any[]): void
   error(message: string, ...args: any[]): void
+  groupCollapsed(groupTitle?: string, ...args: any[]): void
+  groupEnd(): void
 }


### PR DESCRIPTION
This PR adds a debug mode to Stimulus and close [#349](https://github.com/stimulusjs/stimulus/issues/349)

In debug mode _application lifecycles_, _controller lifecycles_ and _actions_ events are sent to the Stimulus `Logger` with a default output to the console. Each log includes context information available in a detailed view.

**Example:**
![Kapture 2020-12-17 at 11 37 18](https://user-images.githubusercontent.com/7847244/102477217-5c060780-405c-11eb-9e7c-f8053cb96b60.gif)

## Usage

debug mode can be enabled during the Stimulus application initialization phase

```js
import { Application } from 'stimulus'
import { definitionsFromContext } from 'stimulus/webpack-helpers'

const application = Application.start()
const context = require.context('./controllers', true, /\.js$/)
application.load(definitionsFromContext(context))

// enable Stimulus debug mode in development
application.debug = process.env.NODE_ENV === 'development'
```

Or even at run time as suggested [here](https://github.com/stimulusjs/stimulus/issues/349#issuecomment-743285759) if `application` is accessible at the window level.

```js
window.stimulusApplication = application

// and then in the console 
stimulusApplication.debug = true // or false to toggle the debug mode in production
```

## Message content & styling

#### Content

Messages are collapsed groups. Title of the group follow the pattern `emitter #action`
The emitter can be `application` or a `controller identifier`

**Examples:**
- `application #staring`
- `application #stared`
- `form #initialize`
- `form #connect`
- `form #submit` -> action

Opening the group provides a context object with details:

- application (all)
- controller (controller lifecycle and actions)
- element (controller lifecycle and actions)
- identifier (controller lifecycle and actions)
- functionName (actions)
- currentTarget (actions)
- event (actions)
- target (actions)

#### Style

I applied a few colors with a variant for dark mode. I took Purple and Yellow from Basecamp website. Matter of taste and easily changeable.

|light mode|dark mode|
|---|---|
|![Screen Shot 2020-12-17 at 11 13 42 AM](https://user-images.githubusercontent.com/7847244/102474500-03813b00-4059-11eb-9c3a-69bad644475b.jpg)|![Screen Shot 2020-12-17 at 11 12 54 AM](https://user-images.githubusercontent.com/7847244/102474512-067c2b80-4059-11eb-95eb-3037902c38ac.jpg)|


## Values

Value changes are not logged at this point. It shouldn't be difficult to add if needed.

## Namespacing

No particular namespace is applied to the log message at this point. This is a subject of discussion. Do we want something like : 

`Stimulus - emitter #action` for the collapsed group title ?

### Custom logger

By default, the logger is the `console`. A custom `Logger`can be supply

```js
application.logger = customLogger
```

### Tests

This PR does not include tests at this point. I am not sure how you would like this to be tested. One approach I could think of is to create a custom Logger that would collect messages (could store them in the `application`). And then do some assertion on the amount of messages and type we receive. An approach a bit similar to the `log_controller_test_case` but at the application level this time.
