### PR TITLE
Change the default event for checkbox and radio inputs from "input" back to "change"

### DIFF
--- a/docs/handbook/03_building_something_real.md
+++ b/docs/handbook/03_building_something_real.md
@@ -93,15 +93,17 @@ We want a click on the button to invoke the `copy()` method in our controller, s
 >
 > Certain other elements have default events, too. Here's the full list:
 >
-> Element           | Default Event
-> ----------------- | -------------
-> a                 | click
-> button            | click
-> form              | submit
-> input             | input
-> input type=submit | click
-> select            | change
-> textarea          | input
+> Element             | Default Event
+> ------------------- | -------------
+> a                   | click
+> button              | click
+> form                | submit
+> input               | input
+> input type=checkbox | change
+> input type=radio    | change
+> input type=submit   | click
+> select              | change
+> textarea            | input
 
 Finally, in our `copy()` method, we can select the input field's contents and call the clipboard API:
 

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -54,15 +54,17 @@ Stimulus lets you shorten the action descriptors for some common element/event p
 
 The full set of these shorthand pairs is as follows:
 
-Element           | Default Event
------------------ | -------------
-a                 | click
-button            | click
-form              | submit
-input             | input
-input type=submit | click
-select            | change
-textarea          | input
+Element             | Default Event
+------------------- | -------------
+a                   | click
+button              | click
+form                | submit
+input               | input
+input type=checkbox | change
+input type=radio    | change
+input type=submit   | click
+select              | change
+textarea            | input
 
 ### Global Events
 

--- a/packages/@stimulus/core/src/action.ts
+++ b/packages/@stimulus/core/src/action.ts
@@ -38,7 +38,13 @@ const defaultEventNames: { [tagName: string]: (element: Element) => string } = {
   "a":        e => "click",
   "button":   e => "click",
   "form":     e => "submit",
-  "input":    e => e.getAttribute("type") == "submit" ? "click" : "input",
+  "input":    e => {
+    switch (e.getAttribute("type")) {
+      case "submit": return "click";
+      case "checkbox": case "radio": return "change";
+      default: return "input";
+    }
+  },
   "select":   e => "change",
   "textarea": e => "input"
 }


### PR DESCRIPTION
https://github.com/stimulusjs/stimulus/commit/14ba2abf75c7ce97e015199996239645d93cd1a9 changed the default event for all `input` elements (except for submit) from `change` to `input`. While this is great for most inputs, radio and checkbox inputs stopped functioning properly, since they do not fire input events at all. This PR aims to resolve this issue.

Resolves: https://github.com/stimulusjs/stimulus/issues/248#issuecomment-748596133