### PR TITLE
Target attribute name is part of the schema

### DIFF
--- a/packages/@stimulus/core/src/schema.ts
+++ b/packages/@stimulus/core/src/schema.ts
@@ -2,10 +2,12 @@ export interface Schema {
   controllerAttribute: string
   actionAttribute: string
   targetAttribute: string
+  targetAttributeForScope(identifier: string): string
 }
 
 export const defaultSchema: Schema = {
   controllerAttribute: "data-controller",
   actionAttribute: "data-action",
-  targetAttribute: "data-target"
+  targetAttribute: "data-target",
+  targetAttributeForScope: identifier => `data-${identifier}-target`
 }

--- a/packages/@stimulus/core/src/target_set.ts
+++ b/packages/@stimulus/core/src/target_set.ts
@@ -51,7 +51,7 @@ export class TargetSet {
   }
 
   private getSelectorForTargetName(targetName: string) {
-    const attributeName = `data-${this.identifier}-target`
+    const attributeName = this.schema.targetAttributeForScope(this.identifier)
     return attributeValueContainsToken(attributeName, targetName)
   }
 
@@ -74,8 +74,9 @@ export class TargetSet {
     if (element) {
       const { identifier } = this
       const attributeName = this.schema.targetAttribute
+      const revisedAttributeName = this.schema.targetAttributeForScope(identifier)
       this.guide.warn(element, `target:${targetName}`,
-        `Please replace ${attributeName}="${identifier}.${targetName}" with data-${identifier}-target="${targetName}". ` +
+        `Please replace ${attributeName}="${identifier}.${targetName}" with ${revisedAttributeName}="${targetName}". ` +
         `The ${attributeName} attribute is deprecated and will be removed in a future version of Stimulus.`)
     }
     return element


### PR DESCRIPTION
The schema supplies the actual attribute names.  This needn't change when it's functional.
