### PR TITLE
Provide hook for an autoloader.

### DIFF
--- a/packages/@stimulus/core/src/application.ts
+++ b/packages/@stimulus/core/src/application.ts
@@ -6,11 +6,14 @@ import { Logger } from "./logger"
 import { Router } from "./router"
 import { Schema, defaultSchema } from "./schema"
 
+type Autoloader = (identifier: string, application: Application) => void
+
 export class Application implements ErrorHandler {
   readonly element: Element
   readonly schema: Schema
   readonly dispatcher: Dispatcher
   readonly router: Router
+  private autoloader?: Autoloader
   logger: Logger = console
 
   static start(element?: Element, schema?: Schema): Application {
@@ -39,6 +42,14 @@ export class Application implements ErrorHandler {
 
   register(identifier: string, controllerConstructor: ControllerConstructor) {
     this.load({ identifier, controllerConstructor })
+  }
+
+  register_autoloader(autoloader: Autoloader) {
+    this.autoloader = autoloader
+  }
+
+  missing(identifier: string) {
+    this.autoloader?.(identifier, this)
   }
 
   load(...definitions: Definition[]): void

--- a/packages/@stimulus/core/src/router.ts
+++ b/packages/@stimulus/core/src/router.ts
@@ -87,6 +87,7 @@ export class Router implements ScopeObserverDelegate {
 
   /** @hidden */
   scopeConnected(scope: Scope) {
+    this.checkForMissingModule(scope.identifier)
     this.scopesByIdentifier.add(scope.identifier, scope)
     const module = this.modulesByIdentifier.get(scope.identifier)
     if (module) {
@@ -100,6 +101,13 @@ export class Router implements ScopeObserverDelegate {
     const module = this.modulesByIdentifier.get(scope.identifier)
     if (module) {
       module.disconnectContextForScope(scope)
+    }
+  }
+
+  /** @hidden */
+  private checkForMissingModule(identifier: string) {
+    if (!this.modulesByIdentifier.has(identifier)) {
+      this.application.missing(identifier)
     }
   }
 

--- a/packages/@stimulus/core/src/tests/modules/application_tests.ts
+++ b/packages/@stimulus/core/src/tests/modules/application_tests.ts
@@ -60,6 +60,23 @@ export default class ApplicationTests extends ApplicationTestCase {
     this.assert.equal(this.controllers[1].connectCount, 1)
   }
 
+  async "test autoloading a module"() {
+    let did_autoload = false
+
+    this.application.register_autoloader((name, app) => {
+      this.assert.equal("log", name)
+      app.register(name, LogController)
+      did_autoload = true
+    })
+
+    this.assert.equal(this.controllers.length, 0)
+    this.assert.equal(did_autoload, false)
+    await this.renderFixture(`<div data-controller="log">`)
+    this.assert.equal(this.controllers[0].initializeCount, 1)
+    this.assert.equal(this.controllers[0].connectCount, 1)
+    this.assert.equal(did_autoload, true)
+  }
+
   get controllers() {
     return this.application.controllers as LogController[]
   }


### PR DESCRIPTION
Add a hook for an outboard autoloader. Suggested usage like:

```
import { Application } from "stimulus"

const controllerFilename = name => `${name.replace(/--/g, "/").replace(/-/g, "_")}_controller`

const application = new Application()
application.register_autoloader((name, app) => {
  import(controllerFilename(name))
    .then(module => app.register(name, module.default))
    .catch(error => console.log(`Failed to autoload controller: ${name}`, error))
})
application.start()
```
