### PR TITLE
Add @stimulus/multimap to core deps

### DIFF
--- a/packages/@stimulus/core/package.json
+++ b/packages/@stimulus/core/package.json
@@ -14,6 +14,7 @@
   "types": "dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
+    "@stimulus/multimap": "^2.0.0",
     "@stimulus/mutation-observers": "^2.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
## Changes

This is a simple fix: in `@stimulus/core`, it imports `@stimulus/multimap` (such as [router.ts#L5](https://github.com/hotwired/stimulus/blob/main/packages/@stimulus/core/src/router.ts#L5)) but forgets to include it in its own dependencies. This PR just adds that.