### PR TITLE
Add texts on using static get methods for classes, targets and values

### DIFF
--- a/docs/reference/css_classes.md
+++ b/docs/reference/css_classes.md
@@ -38,6 +38,15 @@ export default class extends Controller {
 }
 ```
 
+When using Stimulus without a build system, define CSS classes using `static get classes()` methods instead of `static classes = […]` class properties, which aren't supported natively [yet](https://github.com/tc39/proposal-static-class-features/).
+
+```js
+static get classes() {
+  return [ "loading" ]
+}
+```
+
+
 ## Attributes
 
 The logical names defined in the controller's `static classes` array map to _CSS class attributes_ on the controller's element.

--- a/docs/reference/targets.md
+++ b/docs/reference/targets.md
@@ -46,6 +46,14 @@ export default class extends Controller {
 }
 ```
 
+When using Stimulus without a build system, define targets using `static get targets()` methods instead of `static targets = […]` class properties, which aren't supported natively [yet](https://github.com/tc39/proposal-static-class-features/).
+
+```js
+static get targets() {
+  return [ "query", "errorMessage", "results" ]
+}
+```
+
 ## Properties
 
 For each target name defined in the `static targets` array, Stimulus adds the following properties to your controller, where `[name]` corresponds to the target's name:

--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -48,6 +48,18 @@ export default class extends Controller {
 }
 ```
 
+When using Stimulus without a build system, define values using `static get values()` methods instead of `static values = {…}` class properties, which aren't supported natively [yet](https://github.com/tc39/proposal-static-class-features/).
+
+```js
+static get values() {
+  return  {
+    url: String,
+    interval: Number,
+    params: Object
+  }
+}
+```
+
 ## Types
 
 A value's type is one of `Array`, `Boolean`, `Number`, `Object`, or `String`. The type determines how the value is transcoded between JavaScript and HTML.

--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -52,7 +52,7 @@ When using Stimulus without a build system, define values using `static get valu
 
 ```js
 static get values() {
-  return  {
+  return {
     url: String,
     interval: Number,
     params: Object


### PR DESCRIPTION
This pull request adds explicit examples of using `static get ...` to the definition sections of the targets, values and CSS classes reference pages.

As a person who doesn't work daily with Javascript and uses webpacker-free Rails, I often find myself forgetting the appropriate syntax when checking the reference. Specifically, the only reference to using `static get targets()` is buried at the bottom of the [Handbook](https://stimulus.hotwire.dev/handbook/installing#using-without-a-build-system).

Although not included in this PR, [2: Hello, Stimulus](https://stimulus.hotwire.dev/handbook/hello-stimulus) in the Handbook suggests to "Remix on Glitch", which I tried, and Glitch also doesn't accept the static class properties, so maybe a note on alternate syntax should be added there as well?
