### PR TITLE
Utilize Javscript Number to parse 'Number' values

### DIFF
--- a/packages/@stimulus/core/src/tests/modules/value_tests.ts
+++ b/packages/@stimulus/core/src/tests/modules/value_tests.ts
@@ -42,6 +42,10 @@ export default class ValueTests extends ControllerTestCase(ValueController) {
     this.controller.numericValue = "garbage" as any
     this.assert.ok(isNaN(this.controller.numericValue))
     this.assert.equal(this.get("numeric-value"), "garbage")
+
+    this.controller.numericValue = "" as any
+    this.assert.equal(this.controller.numericValue, 0)
+    this.assert.equal(this.get("numeric-value"), "")
   }
 
   "test boolean values"() {

--- a/packages/@stimulus/core/src/value_properties.ts
+++ b/packages/@stimulus/core/src/value_properties.ts
@@ -122,7 +122,7 @@ const readers: { [type: string]: Reader } = {
   },
 
   number(value: string): number {
-    return parseFloat(value)
+    return Number(value)
   },
 
   object(value: string): object {


### PR DESCRIPTION
When processing an incoming empty string against a value property with type Number, the result is NaN. However, if we utilize [Javascript Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) to parse the incoming empty string, we will get a `0`. This is ideal as the default for a Number value property is `0`.

It appears to have browser coverage needed, with no downside that I could find to cover these cases.