### PR TITLE
Add `oldValue` argument to `{name}ValueChanged` callback

### DIFF
--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -98,7 +98,7 @@ The existential property for a value evaluates to `true` when the associated dat
 
 Value _change callbacks_ let you respond whenever a value's data attribute changes.
 
-Define a method `[name]ValueChanged` in the controller, where `[name]` is the name of the value you want to observe for changes. The method receives its decoded value as the first argument.
+Define a method `[name]ValueChanged` in the controller, where `[name]` is the name of the value you want to observe for changes. The method receives its decoded value as the first argument and the decoded previous value as the second argument.
 
 Stimulus invokes each change callback after the controller is initialized and again any time its associated data attribute changes. This includes changes as a result of assignment to the value's setter.
 
@@ -111,6 +111,22 @@ export default class extends Controller {
   }
 }
 ```
+
+### Previous Values
+
+You can access the previous value of a `[name]ValueChanged` callback by defining the callback method with two arguments in your controller.
+
+```js
+export default class extends Controller {
+  static values = { url: String }
+
+  urlValueChanged(value, previousValue) {
+    /* … */
+  }
+}
+```
+
+The two arguments can be named as you like. You could also use `urlValueChanged(current, old)`.
 
 ## Naming Conventions
 

--- a/packages/@stimulus/core/src/tests/controllers/value_controller.ts
+++ b/packages/@stimulus/core/src/tests/controllers/value_controller.ts
@@ -29,12 +29,23 @@ export class ValueController extends BaseValueController {
   time24hrValue!: Boolean
 
   loggedNumericValues: number[] = []
-  numericValueChanged(value: number) {
+  oldLoggedNumericValues: any[] = []
+  numericValueChanged(value: number, oldValue: any) {
     this.loggedNumericValues.push(value)
+    this.oldLoggedNumericValues.push(oldValue)
   }
 
   loggedMissingStringValues: string[] = []
-  missingStringValueChanged(value: string) {
+  oldLoggedMissingStringValues: any[] = []
+  missingStringValueChanged(value: string, oldValue: any) {
     this.loggedMissingStringValues.push(value)
+    this.oldLoggedMissingStringValues.push(oldValue)
+  }
+
+  optionsValues: Object[] = []
+  oldOptionsValues: any[] = []
+  optionsValueChanged(value: Object, oldValue: any) {
+    this.optionsValues.push(value)
+    this.oldOptionsValues.push(oldValue)
   }
 }

--- a/packages/@stimulus/core/src/tests/modules/value_tests.ts
+++ b/packages/@stimulus/core/src/tests/modules/value_tests.ts
@@ -140,26 +140,47 @@ export default class ValueTests extends ControllerTestCase(ValueController) {
 
   async "test changed callbacks"() {
     this.assert.deepEqual(this.controller.loggedNumericValues, [123])
+    this.assert.deepEqual(this.controller.oldLoggedNumericValues, [0])
 
     this.controller.numericValue = 0
     await this.nextFrame
     this.assert.deepEqual(this.controller.loggedNumericValues, [123, 0])
+    this.assert.deepEqual(this.controller.oldLoggedNumericValues, [0, 123])
 
     this.set("numeric-value", "1")
     await this.nextFrame
     this.assert.deepEqual(this.controller.loggedNumericValues, [123, 0, 1])
+    this.assert.deepEqual(this.controller.oldLoggedNumericValues, [0, 123, 0])
+  }
+
+  async "test changed callbacks for object"() {
+    this.assert.deepEqual(this.controller.optionsValues, [{ one: [2, 3] }])
+    this.assert.deepEqual(this.controller.oldOptionsValues, [{}])
+
+    this.controller.optionsValue = { person: { name: 'John', age: 42, active: true } }
+    await this.nextFrame
+    this.assert.deepEqual(this.controller.optionsValues, [{ one: [2, 3] }, { person: { name: 'John', age: 42, active: true } }])
+    this.assert.deepEqual(this.controller.oldOptionsValues, [{}, { one: [2, 3] }])
+
+    this.set("options-value", "{}")
+    await this.nextFrame
+    this.assert.deepEqual(this.controller.optionsValues, [{ one: [2, 3] }, { person: { name: 'John', age: 42, active: true } }, {}])
+    this.assert.deepEqual(this.controller.oldOptionsValues, [{}, { one: [2, 3] }, { person: { name: 'John', age: 42, active: true } }])
   }
 
   async "test default values trigger changed callbacks"() {
     this.assert.deepEqual(this.controller.loggedMissingStringValues, [""])
+    this.assert.deepEqual(this.controller.oldLoggedMissingStringValues, [undefined])
 
     this.controller.missingStringValue = "hello"
     await this.nextFrame
     this.assert.deepEqual(this.controller.loggedMissingStringValues, ["", "hello"])
+    this.assert.deepEqual(this.controller.oldLoggedMissingStringValues, [undefined, ""])
 
     this.controller.missingStringValue = undefined as any
     await this.nextFrame
     this.assert.deepEqual(this.controller.loggedMissingStringValues, ["", "hello", ""])
+    this.assert.deepEqual(this.controller.oldLoggedMissingStringValues, [undefined, "", "hello"])
   }
 
   "test keys may be specified in kebab-case"() {

--- a/packages/@stimulus/core/src/value_observer.ts
+++ b/packages/@stimulus/core/src/value_observer.ts
@@ -1,6 +1,7 @@
 import { Context } from "./context"
 import { StringMapObserver, StringMapObserverDelegate } from "@stimulus/mutation-observers"
 import { ValueDescriptor } from "./value_properties"
+import { capitalize } from "./string_helpers"
 
 export class ValueObserver implements StringMapObserverDelegate {
   readonly context: Context
@@ -40,29 +41,70 @@ export class ValueObserver implements StringMapObserverDelegate {
     }
   }
 
-  stringMapValueChanged(attributeValue: string | null, name: string) {
-    this.invokeChangedCallbackForValue(name)
+  stringMapKeyAdded(key: string, attributeName: string) {
+    const descriptor = this.valueDescriptorMap[attributeName]
+
+    if (!this.hasValue(key)) {
+      this.invokeChangedCallbackForValue(key, descriptor.defaultValue)
+    }
+  }
+
+  stringMapValueChanged(value: string | null, name: string, oldValue: string | null) {
+    this.invokeChangedCallbackForValue(name, oldValue)
+  }
+
+  stringMapKeyRemoved(key: string, attributeName: string, oldValue: string | null) {
+    if (this.hasValue(key)) {
+      this.invokeChangedCallbackForValue(key, oldValue)
+    }
   }
 
   private invokeChangedCallbacksForDefaultValues() {
     for (const { key, name, defaultValue } of this.valueDescriptors) {
       if (defaultValue != undefined && !this.controller.data.has(key)) {
-        this.invokeChangedCallbackForValue(name)
+        this.invokeChangedCallbackForValue(name, null)
       }
     }
   }
 
-  private invokeChangedCallbackForValue(name: string) {
-    const methodName = `${name}Changed`
-    const method = this.receiver[methodName]
-    if (typeof method == "function") {
+  private invokeChangedCallbackForValue(name: string, oldValue: string | null) {
+    const changedMethodName = `${name}Changed`
+    const changedMethod = this.receiver[changedMethodName]
+
+    if (typeof changedMethod == "function") {
       const value = this.receiver[name]
-      method.call(this.receiver, value)
+      const descriptor = this.valueDescriptorNameMap[name]
+
+      if (oldValue) {
+        changedMethod.call(this.receiver, value, descriptor.reader(oldValue))
+      } else if (this.hasValue(name)) {
+        changedMethod.call(this.receiver, value, descriptor.defaultValue)
+      } else {
+        changedMethod.call(this.receiver, value)
+      }
     }
   }
 
   private get valueDescriptors() {
     const { valueDescriptorMap } = this
     return Object.keys(valueDescriptorMap).map(key => valueDescriptorMap[key])
+  }
+
+  private get valueDescriptorNameMap() {
+    const descriptors: { [type: string]: ValueDescriptor }  = {}
+
+    Object.keys(this.valueDescriptorMap).forEach(key => {
+      const descriptor = this.valueDescriptorMap[key]
+      descriptors[descriptor.name] = descriptor
+    })
+
+    return descriptors
+  }
+
+  private hasValue(attributeName: string) {
+    const descriptor = this.valueDescriptorNameMap[attributeName]
+    const hasMethodName = `has${capitalize(descriptor.name)}`
+
+    return this.receiver[hasMethodName]
   }
 }

--- a/packages/@stimulus/core/src/value_properties.ts
+++ b/packages/@stimulus/core/src/value_properties.ts
@@ -24,8 +24,7 @@ export function ValuePropertiesBlessing<T>(constructor: Constructor<T>) {
 
 export function propertiesForValueDefinitionPair<T>(valueDefinitionPair: ValueDefinitionPair): PropertyDescriptorMap {
   const definition = parseValueDefinitionPair(valueDefinitionPair)
-  const { type, key, name } = definition
-  const read = readers[type], write = writers[type] || writers.default
+  const { key, name, reader: read, writer: write } = definition
 
   return {
     [name]: {
@@ -59,7 +58,9 @@ export type ValueDescriptor = {
   type: ValueType,
   key: string,
   name: string,
-  defaultValue: any
+  defaultValue: any,
+  reader: Reader,
+  writer: Writer
 }
 
 export type ValueDescriptorMap = { [attributeName: string]: ValueDescriptor }
@@ -94,7 +95,9 @@ function valueDescriptorForTokenAndType(token: string, type: ValueType) {
     type,
     key,
     name: camelize(key),
-    get defaultValue() { return defaultValuesByType[type] }
+    get defaultValue() { return defaultValuesByType[type] },
+    reader: readers[type],
+    writer: writers[type] || writers.default
   }
 }
 


### PR DESCRIPTION
This PR adds a second argument to the `{name}ValueChanged` callback which holds the previous value.

Here is a simple example:

```js
import { Controller } from "stimulus"

export default class extends Controller {
  static values = { index: Number }

  connect() {
    this.indexValue = 1
  }

  next() {
    this.indexValue++
  }

  indexValueChanged(value, oldValue) {
    console.log("indexValue", value, oldValue)
  }
}
```

This will be printed if this controller connects and `next()` is called once:
```js
"indexValue" - 0 - undefined    // initialize default value
"indexValue" - 1 - 0            // connect()
"indexValue" - 2 - 1            // next()
```

If you have any feedback please let me know. I'm also happy to add documentation.

Thanks!

Resolves https://github.com/hotwired/stimulus/issues/346