### PR TITLE
Docs: add 'decoded as' to values reference

### DIFF
--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -52,13 +52,13 @@ export default class extends Controller {
 
 A value's type is one of `Array`, `Boolean`, `Number`, `Object`, or `String`. The type determines how the value is transcoded between JavaScript and HTML.
 
-Type | Encoded as…
----- | -----------
-Array | `JSON.stringify(array)`
-Boolean | `boolean.toString()`
-Number | `number.toString()`
-Object | `JSON.stringify(object)`
-String | Itself
+Type | Encoded as… | Decoded as…
+---- | ----------- | -----------
+Array | `JSON.stringify(array)` | `JSON.parse(value)`
+Boolean | `boolean.toString()` | `!(value == "0" \|\| value == "false")`
+Number | `number.toString()` | `Number(value)`
+Object | `JSON.stringify(object)` | `JSON.parse(value)`
+String | Itself | Itself
 
 ## Properties and Attributes
 


### PR DESCRIPTION
See #396 for discussion