### PR TITLE
Fire callbacks when targets are added or removed

### DIFF
--- a/docs/reference/lifecycle_callbacks.md
+++ b/docs/reference/lifecycle_callbacks.md
@@ -27,7 +27,9 @@ Method       | Invoked by Stimulus…
 ------------ | --------------------
 initialize() | Once, when the controller is first instantiated
 connect()    | Anytime the controller is connected to the DOM
+[name]TargetConnected(target: Element) | Anytime a target is connected to the DOM
 disconnect() | Anytime the controller is disconnected from the DOM
+[name]TargetDisconnected(target: Element) | Anytime a target is disconnected from the DOM
 
 ## Connection
 
@@ -37,6 +39,15 @@ A controller is _connected_ to the document when both of the following condition
 * its identifier is present in the element's `data-controller` attribute
 
 When a controller becomes connected, Stimulus calls its `connect()` method.
+
+### Targets
+
+A target is _connected_ to the document when both of the following conditions are true:
+
+* its element is present in the document as a descendant of its corresponding controller's element
+* its identifier is present in the element's `data-{identifier}-target` attribute
+
+When a target becomes connected, Stimulus calls its controller's `[name]TargetConnected()` method, passing the target element as a parameter.
 
 ## Disconnection
 
@@ -50,11 +61,25 @@ A connected controller will later become _disconnected_ when either of the prece
 
 When a controller becomes disconnected, Stimulus calls its `disconnect()` method.
 
+### Targets
+
+A connected target will later become _disconnected_ when either of the preceding conditions becomes false, such as under any of the following scenarios:
+
+* the element is explicitly removed from the document with `Node#removeChild()` or `ChildNode#remove()`
+* one of the element's parent elements is removed from the document
+* one of the element's parent elements has its contents replaced by `Element#innerHTML=`
+* the element's `data-{identifier}-target` attribute is removed or modified
+* the document installs a new `<body>` element, such as during a Turbo page change
+
+When a target becomes disconnected, Stimulus calls its controller's `[name]TargetDisconnected()` method, passing the target element as a parameter.
+
 ## Reconnection
 
 A disconnected controller may become connected again at a later time.
 
 When this happens, such as after removing the controller's element from the document and then re-attaching it, Stimulus will reuse the element's previous controller instance, calling its `connect()` method multiple times.
+
+Similarly, a disconnected target may be connected again at a later time. Stimulus will invoke its controller's `[name]TargetConnected()` method multiple times.
 
 ## Order and Timing
 

--- a/docs/reference/targets.md
+++ b/docs/reference/targets.md
@@ -88,6 +88,32 @@ if (this.hasResultsTarget) {
 }
 ```
 
+## Connected and Disconnected Callbacks
+
+Target _element callbacks_ let you respond whenever a target element is added or
+removed within the controller's element.
+
+Define a method `[name]TargetConnected` or `[name]TargetDisconnected` in the controller, where `[name]` is the name of the target you want to observe for additions or removals. The method receives the element as the first argument.
+
+Stimulus invokes each element callback any time its target elements are added or removed after `connect()` and before `disconnect()` lifecycle hooks.
+
+```js
+export default class extends Controller {
+  static targets = [ "item" ]
+
+  itemTargetConnected(element) {
+    this.sortElements(this.itemTargets)
+  }
+
+  itemTargetDisconnected(element) {
+    this.sortElements(this.itemTargets)
+  }
+
+  // Private
+  sortElements(itemTargets) { /* ... */ }
+}
+```
+
 ## Naming Conventions
 
 Always use camelCase to specify target names, since they map directly to properties on your controller.

--- a/packages/@stimulus/core/src/context.ts
+++ b/packages/@stimulus/core/src/context.ts
@@ -7,13 +7,15 @@ import { Module } from "./module"
 import { Schema } from "./schema"
 import { Scope } from "./scope"
 import { ValueObserver } from "./value_observer"
+import { TargetObserver, TargetObserverDelegate } from "./target_observer"
 
-export class Context implements ErrorHandler {
+export class Context implements ErrorHandler, TargetObserverDelegate {
   readonly module: Module
   readonly scope: Scope
   readonly controller: Controller
   private bindingObserver: BindingObserver
   private valueObserver: ValueObserver
+  private targetObserver: TargetObserver
 
   constructor(module: Module, scope: Scope) {
     this.module = module
@@ -21,6 +23,7 @@ export class Context implements ErrorHandler {
     this.controller = new module.controllerConstructor(this)
     this.bindingObserver = new BindingObserver(this, this.dispatcher)
     this.valueObserver = new ValueObserver(this, this.controller)
+    this.targetObserver = new TargetObserver(this, this)
 
     try {
       this.controller.initialize()
@@ -33,6 +36,7 @@ export class Context implements ErrorHandler {
   connect() {
     this.bindingObserver.start()
     this.valueObserver.start()
+    this.targetObserver.start()
 
     try {
       this.controller.connect()
@@ -50,6 +54,7 @@ export class Context implements ErrorHandler {
       this.handleError(error, "disconnecting controller")
     }
 
+    this.targetObserver.stop()
     this.valueObserver.stop()
     this.bindingObserver.stop()
   }
@@ -92,5 +97,24 @@ export class Context implements ErrorHandler {
     const { identifier, controller, element } = this
     detail = Object.assign({ identifier, controller, element }, detail)
     this.application.logDebugActivity(this.identifier, functionName, detail)
+  }
+
+  // Target observer delegate
+
+  targetConnected(element: Element, name: string) {
+    this.invokeControllerMethod(`${name}TargetConnected`, element)
+  }
+
+  targetDisconnected(element: Element, name: string) {
+    this.invokeControllerMethod(`${name}TargetDisconnected`, element)
+  }
+
+  // Private
+
+  invokeControllerMethod(methodName: string, ...args: any[]) {
+    const controller: any = this.controller
+    if (typeof controller[methodName] == "function") {
+      controller[methodName](...args)
+    }
   }
 }

--- a/packages/@stimulus/core/src/target_observer.ts
+++ b/packages/@stimulus/core/src/target_observer.ts
@@ -1,0 +1,86 @@
+import { Multimap } from "@stimulus/multimap"
+import { Token, TokenListObserver, TokenListObserverDelegate } from "@stimulus/mutation-observers"
+import { Context } from "./context"
+
+export interface TargetObserverDelegate {
+  targetConnected(element: Element, name: string): void
+  targetDisconnected(element: Element, name: string): void
+}
+
+export class TargetObserver implements TokenListObserverDelegate {
+  readonly context: Context
+  readonly delegate: TargetObserverDelegate
+  readonly targetsByName: Multimap<string, Element>
+  private tokenListObserver?: TokenListObserver
+
+  constructor(context: Context, delegate: TargetObserverDelegate) {
+    this.context = context
+    this.delegate = delegate
+    this.targetsByName = new Multimap
+  }
+
+  start() {
+    if (!this.tokenListObserver) {
+      this.tokenListObserver = new TokenListObserver(this.element, this.attributeName, this)
+      this.tokenListObserver.start()
+    }
+  }
+
+  stop() {
+    if (this.tokenListObserver) {
+      this.disconnectAllTargets()
+      this.tokenListObserver.stop()
+      delete this.tokenListObserver
+    }
+  }
+
+  // Token list observer delegate
+
+  tokenMatched({ element, content: name }: Token) {
+    if (this.scope.containsElement(element)) {
+      this.connectTarget(element, name)
+    }
+  }
+
+  tokenUnmatched({ element, content: name }: Token) {
+    this.disconnectTarget(element, name)
+  }
+
+  // Target management
+
+  connectTarget(element: Element, name: string) {
+    if (!this.targetsByName.has(name, element)) {
+      this.targetsByName.add(name, element)
+      this.delegate.targetConnected(element, name)
+    }
+  }
+
+  disconnectTarget(element: Element, name: string) {
+    if (this.targetsByName.has(name, element)) {
+      this.targetsByName.delete(name, element)
+      this.delegate.targetDisconnected(element, name)
+    }
+  }
+
+  disconnectAllTargets() {
+    for (const name of this.targetsByName.keys) {
+      for (const element of this.targetsByName.getValuesForKey(name)) {
+        this.disconnectTarget(element, name)
+      }
+    }
+  }
+
+  // Private
+
+  private get attributeName() {
+    return `data-${this.context.identifier}-target`
+  }
+
+  private get element() {
+    return this.context.element
+  }
+
+  private get scope() {
+    return this.context.scope
+  }
+}

--- a/packages/@stimulus/core/src/tests/controllers/target_controller.ts
+++ b/packages/@stimulus/core/src/tests/controllers/target_controller.ts
@@ -9,7 +9,9 @@ class BaseTargetController extends Controller {
 }
 
 export class TargetController extends BaseTargetController {
+  static classes = [ "connected", "disconnected" ]
   static targets = [ "beta", "input" ]
+  static values = { inputTargetConnectedCallCount: Number, inputTargetDisconnectedCallCount: Number }
 
   betaTarget!: Element | null
   betaTargets!: Element[]
@@ -18,4 +20,22 @@ export class TargetController extends BaseTargetController {
   inputTarget!: Element | null
   inputTargets!: Element[]
   hasInputTarget!: boolean
+
+  hasConnectedClass!: boolean
+  hasDisconnectedClass!: boolean
+  connectedClass!: string
+  disconnectedClass!: string
+
+  inputTargetConnectedCallCountValue = 0
+  inputTargetDisconnectedCallCountValue = 0
+
+  inputTargetConnected(element: Element) {
+    if (this.hasConnectedClass) element.classList.add(this.connectedClass)
+    this.inputTargetConnectedCallCountValue++
+  }
+
+  inputTargetDisconnected(element: Element) {
+    if (this.hasDisconnectedClass) element.classList.add(this.disconnectedClass)
+    this.inputTargetDisconnectedCallCountValue++
+  }
 }

--- a/packages/@stimulus/core/src/tests/modules/target_tests.ts
+++ b/packages/@stimulus/core/src/tests/modules/target_tests.ts
@@ -3,7 +3,7 @@ import { TargetController } from "../controllers/target_controller"
 
 export default class TargetTests extends ControllerTestCase(TargetController) {
   fixtureHTML = `
-    <div data-controller="${this.identifier}">
+    <div data-controller="${this.identifier}" data-${this.identifier}-connected-class="connected" data-${this.identifier}-disconnected-class="disconnected">
       <div data-${this.identifier}-target="alpha" id="alpha1"></div>
       <div data-${this.identifier}-target="alpha" id="alpha2"></div>
       <div data-${this.identifier}-target="beta" id="beta1">
@@ -12,7 +12,7 @@ export default class TargetTests extends ControllerTestCase(TargetController) {
       <div data-controller="${this.identifier}" id="child">
         <div data-${this.identifier}-target="delta" id="delta1"></div>
       </div>
-      <textarea data-${this.identifier}-target="input" id="input1"></textarea>
+      <textarea data-${this.identifier}-target="omega input" id="input1"></textarea>
     </div>
   `
 
@@ -61,5 +61,107 @@ export default class TargetTests extends ControllerTestCase(TargetController) {
     this.assert.equal(this.controller.hasBetaTarget, false)
     this.assert.equal(this.controller.betaTargets.length, 0)
     this.assert.throws(() => this.controller.betaTarget)
+  }
+
+  "test target connected callback fires after initialize() and when calling connect()"() {
+    const connectedInputs = this.controller.inputTargets.filter(target => target.classList.contains("connected"))
+
+    this.assert.equal(connectedInputs.length, 1)
+    this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 1)
+  }
+
+  async "test target connected callback when element is inserted"() {
+    const connectedInput = document.createElement("input")
+    connectedInput.setAttribute(`data-${this.controller.identifier}-target`, "input")
+
+    this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 1)
+
+    this.controller.element.appendChild(connectedInput)
+    await this.nextFrame
+
+    this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 2)
+    this.assert.ok(connectedInput.classList.contains("connected"), `expected "${connectedInput.className}" to contain "connected"`)
+    this.assert.ok(connectedInput.isConnected, "element is present in document")
+  }
+
+  async "test target connected callback when present element adds the target attribute"() {
+    const element = this.findElement("#alpha1")
+
+    this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 1)
+
+    element.setAttribute(`data-${this.controller.identifier}-target`, "input")
+    await this.nextFrame
+
+    this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 2)
+    this.assert.ok(element.classList.contains("connected"), `expected "${element.className}" to contain "connected"`)
+    this.assert.ok(element.isConnected, "element is still present in document")
+  }
+
+  async "test target connected callback when element adds a token to an existing target attribute"() {
+    const element = this.findElement("#alpha1")
+
+    this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 1)
+
+    element.setAttribute(`data-${this.controller.identifier}-target`, "alpha input")
+    await this.nextFrame
+
+    this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 2)
+    this.assert.ok(element.classList.contains("connected"), `expected "${element.className}" to contain "connected"`)
+    this.assert.ok(element.isConnected, "element is still present in document")
+  }
+
+  async "test target disconnected callback fires when calling disconnect() on the controller"() {
+    this.assert.equal(this.controller.inputTargets.filter(target => target.classList.contains("disconnected")).length, 0)
+    this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 0)
+
+    this.controller.context.disconnect()
+    await this.nextFrame
+
+    this.assert.equal(this.controller.inputTargets.filter(target => target.classList.contains("disconnected")).length, 1)
+    this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 1)
+  }
+
+  async "test target disconnected callback when element is removed"() {
+    const disconnectedInput = this.findElement("#input1")
+
+    this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 0)
+    this.assert.notOk(disconnectedInput.classList.contains("disconnected"), `expected "${disconnectedInput.className}" not to contain "disconnected"`)
+
+    disconnectedInput.parentElement?.removeChild(disconnectedInput)
+    await this.nextFrame
+
+    this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 1)
+    this.assert.ok(disconnectedInput.classList.contains("disconnected"), `expected "${disconnectedInput.className}" to contain "disconnected"`)
+    this.assert.notOk(disconnectedInput.isConnected, "element is not present in document")
+  }
+
+  async "test target disconnected callback when an element present in the document removes the target attribute"() {
+    const element = this.findElement("#input1")
+
+    this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 0)
+    this.assert.notOk(element.classList.contains("disconnected"), `expected "${element.className}" not to contain "disconnected"`)
+
+    element.removeAttribute(`data-${this.controller.identifier}-target`)
+    await this.nextFrame
+
+    this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 1)
+    this.assert.ok(element.classList.contains("disconnected"), `expected "${element.className}" to contain "disconnected"`)
+    this.assert.ok(element.isConnected, "element is still present in document")
+  }
+
+  async "test target disconnected(), then connected() callback fired when the target name is present after the attribute change"() {
+    const element = this.findElement("#input1")
+
+    this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 1)
+    this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 0)
+    this.assert.notOk(element.classList.contains("disconnected"), `expected "${element.className}" not to contain "disconnected"`)
+
+    element.setAttribute(`data-${this.controller.identifier}-target`, "input")
+    await this.nextFrame
+
+    this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 2)
+    this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 1)
+    this.assert.ok(element.classList.contains("disconnected"), `expected "${element.className}" to contain "disconnected"`)
+    this.assert.ok(element.isConnected, "element is still present in document")
   }
 }

--- a/packages/@stimulus/examples/controllers/content_loader_controller.js
+++ b/packages/@stimulus/examples/controllers/content_loader_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
+  static targets = ["item"]
   static values = { url: String, refreshInterval: Number }
 
   connect() {
@@ -9,6 +10,14 @@ export default class extends Controller {
     if (this.hasRefreshIntervalValue) {
       this.startRefreshing()
     }
+  }
+
+  itemTargetConnected(target) {
+    console.log("itemTargetConnected:", target)
+  }
+
+  itemTargetDisconnected(target) {
+    console.log("itemTargetDisconnected:", target)
   }
 
   disconnect() {

--- a/packages/@stimulus/examples/server.js
+++ b/packages/@stimulus/examples/server.js
@@ -29,7 +29,7 @@ app.get("/", (req, res) => {
 })
 
 app.get("/uptime", (req, res, next) => {
-  res.send(process.uptime().toString())
+  res.send(`<span data-content-loader-target="item">${process.uptime().toString()}</span>`)
 })
 
 app.get("/:page", (req, res, next) => {

--- a/packages/@stimulus/multimap/src/multimap.ts
+++ b/packages/@stimulus/multimap/src/multimap.ts
@@ -7,6 +7,10 @@ export class Multimap<K, V> {
     this.valuesByKey = new Map<K, Set<V>>()
   }
 
+  get keys() {
+    return Array.from(this.valuesByKey.keys())
+  }
+
   get values(): V[] {
     const sets = Array.from(this.valuesByKey.values())
     return sets.reduce((values, set) => values.concat(Array.from(set)), <V[]> [])

--- a/packages/@stimulus/polyfills/index.js
+++ b/packages/@stimulus/polyfills/index.js
@@ -15,3 +15,18 @@ if (typeof SVGElement.prototype.contains != "function") {
     return this === node || this.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_CONTAINED_BY
   }
 }
+
+// From https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected#polyfill
+if (!("isConnected" in Node.prototype)) {
+  Object.defineProperty(Node.prototype, "isConnected", {
+    get() {
+      return (
+        !this.ownerDocument ||
+        !(
+          this.ownerDocument.compareDocumentPosition(this) &
+          this.DOCUMENT_POSITION_DISCONNECTED
+        )
+      )
+    }
+  })
+}


### PR DESCRIPTION
I take no credit for this, Sean Doyle did all the hard work in #367. If Sean no longer wants to commit his time to maintaining this PR, I understand. But it would be a terrible shame for this work to be abandoned at the 11th hour, as this is a piece of functionality I think a lot of Stimulus developers have on their wishlist. 

If all parties are happy for the work he did to still go forward, I'm happy to take this over the line. 

