### PR TITLE
Explicitly cast the type param in the dispatch method

### DIFF
--- a/packages/@stimulus/core/src/context.ts
+++ b/packages/@stimulus/core/src/context.ts
@@ -88,7 +88,7 @@ export class Context implements ErrorHandler, TargetObserverDelegate {
 
   dispatch(eventName: String, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true } = {}) {
     const type = prefix ? `${prefix}:${eventName}` : eventName
-    const event = new CustomEvent(type, { detail, bubbles, cancelable })
+    const event = new CustomEvent(type as string, { detail, bubbles, cancelable })
     target.dispatchEvent(event)
     return event
   }


### PR DESCRIPTION
Fixes the TypeScript error which made the test build fail in this PR:
https://github.com/hotwired/stimulus/pull/302