### PR TITLE
CI - Fix TS errors and test breakages regarding IE11 compatibility

### DIFF
--- a/packages/@stimulus/core/src/context.ts
+++ b/packages/@stimulus/core/src/context.ts
@@ -86,7 +86,7 @@ export class Context implements ErrorHandler, TargetObserverDelegate {
     return this.element.parentElement
   }
 
-  dispatch(eventName: String, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true } = {}) {
+  dispatch(eventName: string, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true } = {}) {
     const type = prefix ? `${prefix}:${eventName}` : eventName
     const event = new CustomEvent(type, { detail, bubbles, cancelable })
     target.dispatchEvent(event)

--- a/packages/@stimulus/polyfills/index.js
+++ b/packages/@stimulus/polyfills/index.js
@@ -20,7 +20,7 @@ if (typeof SVGElement.prototype.contains != "function") {
 // From https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected#polyfill
 if (!("isConnected" in Node.prototype)) {
   Object.defineProperty(Node.prototype, "isConnected", {
-    get() {
+    get: function() {
       return (
         !this.ownerDocument ||
         !(


### PR DESCRIPTION
Following on from #415, this fixes the Node.isConnected polyfill that was shipped in #409

IE11 doesn't like the shorthand for an object property that contains a function, i.e:
```
{
  get() {}
}
``` 

Expanding the syntax to the following worked in manual testing. Should resolve the CI failures. 
```
{
  get: function () {}
}
``` 