### PR TITLE
Fix falsey custom default values

### DIFF
--- a/packages/@stimulus/core/src/tests/controllers/default_value_controller.ts
+++ b/packages/@stimulus/core/src/tests/controllers/default_value_controller.ts
@@ -13,6 +13,7 @@ export class DefaultValueController extends Controller {
 
     defaultNumber: 0,
     defaultNumberThousand: { type: Number, default: 1000 },
+    defaultNumberZero: { type: Number, default: 0 },
     defaultNumberOverride: 9999,
 
     defaultArray: [],
@@ -44,6 +45,8 @@ export class DefaultValueController extends Controller {
   hasDefaultNumberValue!: boolean
   defaultNumberThousandValue!: number
   hasDefaultNumberThousandValue!: boolean
+  defaultNumberZeroValue!: number
+  hasDefaultNumberZeroValue!: boolean
   defaultNumberOverrideValue!: number
   hasDefaultNumberOverrideValue!: boolean
 

--- a/packages/@stimulus/core/src/tests/modules/default_value_tests.ts
+++ b/packages/@stimulus/core/src/tests/modules/default_value_tests.ts
@@ -83,6 +83,10 @@ export default class DefaultValueTests extends ControllerTestCase(DefaultValueCo
     this.assert.deepEqual(this.controller.defaultNumberThousandValue, 1000)
     this.assert.ok(this.controller.hasDefaultNumberThousandValue)
     this.assert.deepEqual(this.get("default-number-thousand-value"), null)
+
+    this.assert.deepEqual(this.controller.defaultNumberZeroValue, 0)
+    this.assert.ok(this.controller.hasDefaultNumberZeroValue)
+    this.assert.deepEqual(this.get("default-number-zero-value"), null)
   }
 
   "test should be able to set a new value for custom default number values"() {

--- a/packages/@stimulus/core/src/value_properties.ts
+++ b/packages/@stimulus/core/src/value_properties.ts
@@ -136,8 +136,9 @@ function defaultValueForDefinition(typeDefinition: ValueTypeDefinition): ValueTy
   if (constant) return defaultValuesByType[constant]
 
   const defaultValue = (typeDefinition as ValueTypeObject).default
+  if (defaultValue !== undefined) return defaultValue
 
-  return defaultValue || typeDefinition
+  return typeDefinition
 }
 
 function valueDescriptorForTokenAndTypeDefinition(token: string, typeDefinition: ValueTypeDefinition) {


### PR DESCRIPTION
When specifying `0` as the default value:

```javascript
static values = { index: { type: Number, default: 0 } }
```

The value getter would incorrectly return the type definition:

```javascript
indexValueChanged() {
  console.log(this.indexValue);
  // => { type: Number, default: 0 }
}
```

This seems like an unlikely scenario but it should still be fixed e.g. people may be specifying a default value via an environment variable.