### PR TITLE
Update the Hotwire subdomains

### DIFF
--- a/docs/handbook/00_the_origin_of_stimulus.md
+++ b/docs/handbook/00_the_origin_of_stimulus.md
@@ -17,7 +17,7 @@ And it’s also not to say that the proliferation of single-page JavaScript appl
 
 We wanted Basecamp to feel like that too. As though we had followed the herd and rewritten everything with client-side rendering or gone full-native on mobile.
 
-This desire led us to a two-punch solution: [Turbo](https://turbo.hotwire.dev) and Stimulus.
+This desire led us to a two-punch solution: [Turbo](https://turbo.hotwired.dev) and Stimulus.
 
 ### Turbo up high, Stimulus down low
 

--- a/packages/@stimulus/webpack-helpers/README.md
+++ b/packages/@stimulus/webpack-helpers/README.md
@@ -1,1 +1,1 @@
-The `@stimulus/webpack-helpers` package provides autoload support for Stimulus controllers. See the [Installation Guide](https://stimulus.hotwire.dev/handbook/installing#using-webpack) for details.
+The `@stimulus/webpack-helpers` package provides autoload support for Stimulus controllers. See the [Installation Guide](https://stimulus.hotwired.dev/handbook/installing#using-webpack) for details.


### PR DESCRIPTION
* `https://turbo.hotwire.dev/` → `https://turbo.hotwired.dev/`
* `https://stimulus.hotwire.dev/` → `https://stimulus.hotwired.dev/`

As per: hotwired/hotwire-site@22a11ac