### PR TITLE
update example: use dataset and Number() func

### DIFF
--- a/docs/handbook/05_managing_state.md
+++ b/docs/handbook/05_managing_state.md
@@ -96,7 +96,7 @@ Then, in our `initialize()` method, we could read that attribute, convert it to 
 
 ```js
   initialize() {
-    this.index = parseInt(this.element.getAttribute("data-index"))
+    this.index = Number(this.element.dataset.index)
     this.showCurrentSlide()
   }
 ```


### PR DESCRIPTION
* the`Number()` function for type conversion would in this case be clearer semantically, since no parsing needs to happen, only conversion
* the `data-` attribute can be accessed in JS via `dataset`
  * [JavaScript access - Using data attributes | MDN Web Docs](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes#javascript_access)
  * [HTMLElement.dataset | MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset)