### PR TITLE
Explain how to form identifiers for namespaced controllers in the reference

### DIFF
--- a/docs/reference/controllers.md
+++ b/docs/reference/controllers.md
@@ -45,6 +45,15 @@ For example, this element has a controller which is an instance of the class def
 <div data-controller="reference"></div>
 ```
 
+The following is an example of how Stimulus will generate identifiers for controllers in it's require context:
+
+If your controller file is named… | its identifier will be…
+--------------------------------- | -----------------------
+clipboard_controller.js           | clipboard
+date_picker_controller.js         | date-picker
+users/list_item_controller.js     | users\-\-list-item
+local-time-controller.js          | local-time
+
 ## Scopes
 
 When Stimulus connects a controller to an element, that element and all of its children make up the controller's _scope_.


### PR DESCRIPTION
Hey!
I noticed that the reference is missing an explanation on how to form identifiers for namespaced controllers.

This confused my coworkers and lead them to think that namespacing isn't possible at all, so I though it might be helpful to repeat the instructions from the handbook within the reference's `Identifiers` section.

P.S. I am unsure how `<meta data-controller="callout" data-callout-text-value="articles--reference">` works, and couldn't find a guide how to build the documentation locally to test it, so it's possible I used it incorrectly.