### PR TITLE
Add debug logging for event dispatch helper method

### DIFF
--- a/packages/@stimulus/core/src/application.ts
+++ b/packages/@stimulus/core/src/application.ts
@@ -96,12 +96,18 @@ export class Application implements ErrorHandler {
     }
   }
 
-  private logFormattedMessage(identifier: string, functionName: string, detail: object = {}) {
+  logDebugEvent = (identifier: string, eventName: string, detail: object = {}): void => {
+    if (this.debug) {
+      this.logFormattedMessage(identifier, eventName, detail, '-> ')
+    }
+  }
+
+  private logFormattedMessage(identifier: string, message: string, detail: object = {}, prefix: string = '#') {
     const darkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
     const color = darkMode ? "#ffe000" : "#5D2F85"
     detail = Object.assign({ application: this }, detail)
 
-    this.logger.groupCollapsed(`%c${identifier}%c #${functionName}`, `color: ${color}`, 'color: unset')
+    this.logger.groupCollapsed(`%c${identifier}%c ${prefix}${message}`, `color: ${color}`, 'color: unset')
     this.logger.log("details:", { ...detail })
     this.logger.groupEnd()
   }

--- a/packages/@stimulus/core/src/context.ts
+++ b/packages/@stimulus/core/src/context.ts
@@ -90,6 +90,7 @@ export class Context implements ErrorHandler, TargetObserverDelegate {
     const type = prefix ? `${prefix}:${eventName}` : eventName
     const event = new CustomEvent(type, { detail, bubbles, cancelable })
     target.dispatchEvent(event)
+    this.logDebugEvent(type, detail)
     return event
   }
 
@@ -113,6 +114,12 @@ export class Context implements ErrorHandler, TargetObserverDelegate {
     const { identifier, controller, element } = this
     detail = Object.assign({ identifier, controller, element }, detail)
     this.application.logDebugActivity(this.identifier, functionName, detail)
+  }
+
+  logDebugEvent = (eventName: string, detail: object = {}): void => {
+    const { identifier, controller, element } = this
+    detail = Object.assign({ identifier, controller, element }, detail)
+    this.application.logDebugEvent(this.identifier, eventName, detail)
   }
 
   // Target observer delegate


### PR DESCRIPTION
PR to integrate the changes made in #354 and #302, so that events dispatched using the Stimulus `dispatch` method are logged in debug mode. 

I've found this to be useful when building apps to ensure that events are dispatched on the correct element, and that they are fired when expected. 

Not sure if this will make the debug logging a bit too chatty in certain applications that use a lot of event-based communication between controllers. If so, this might need to be opt-in, rather than always on, but have kept this implementation intentionally simple. 