### PR TITLE
Move dispatch helper from context to controller

### DIFF
--- a/packages/@stimulus/core/src/context.ts
+++ b/packages/@stimulus/core/src/context.ts
@@ -86,13 +86,6 @@ export class Context implements ErrorHandler, TargetObserverDelegate {
     return this.element.parentElement
   }
 
-  dispatch(eventName: string, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true } = {}) {
-    const type = prefix ? `${prefix}:${eventName}` : eventName
-    const event = new CustomEvent(type, { detail, bubbles, cancelable })
-    target.dispatchEvent(event)
-    return event
-  }
-
   // Error handling
 
   handleError(error: Error, message: string, detail: object = {}) {

--- a/packages/@stimulus/core/src/controller.ts
+++ b/packages/@stimulus/core/src/controller.ts
@@ -56,4 +56,11 @@ export class Controller {
   disconnect() {
     // Override in your subclass to respond when the controller is disconnected from the DOM
   }
+
+  dispatch(eventName: string, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true } = {}) {
+    const type = prefix ? `${prefix}:${eventName}` : eventName
+    const event = new CustomEvent(type, { detail, bubbles, cancelable })
+    target.dispatchEvent(event)
+    return event
+  }
 }


### PR DESCRIPTION
fix #431

This feature had no tests linked to it, this is only a patch. Once we get the test suite back on track (#421) I can try to add something simple to ensure it remains functional.