### PR TITLE
Add Controller#shouldLoad

### DIFF
--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -44,7 +44,9 @@ export class Application implements ErrorHandler {
   }
 
   register(identifier: string, controllerConstructor: ControllerConstructor) {
-    this.load({ identifier, controllerConstructor })
+    if (controllerConstructor.shouldLoad) {
+      this.load({ identifier, controllerConstructor })
+    }
   }
 
   load(...definitions: Definition[]): void

--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -44,7 +44,7 @@ export class Application implements ErrorHandler {
   }
 
   register(identifier: string, controllerConstructor: ControllerConstructor) {
-    if (controllerConstructor.shouldLoad) {
+    if ((controllerConstructor as any).shouldLoad) {
       this.load({ identifier, controllerConstructor })
     }
   }

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -11,6 +11,10 @@ export class Controller {
   static targets: string[] = []
   static values: ValueDefinitionMap = {}
 
+  static get shouldLoad() {
+    return true
+  }
+
   readonly context: Context
 
   constructor(context: Context) {

--- a/src/tests/modules/core/application_tests.ts
+++ b/src/tests/modules/core/application_tests.ts
@@ -4,6 +4,11 @@ import { LogController } from "../../controllers/log_controller"
 class AController extends LogController {}
 class BController extends LogController {}
 class CController extends LogController {}
+class DController extends LogController {
+  static get shouldLoad(){
+    return false
+  }
+}
 
 export default class ApplicationTests extends ApplicationTestCase {
   fixtureHTML = `<div data-controller="a"><div data-controller="b">`
@@ -58,6 +63,14 @@ export default class ApplicationTests extends ApplicationTestCase {
     this.assert.ok(this.controllers[1] instanceof CController)
     this.assert.equal(this.controllers[1].initializeCount, 1)
     this.assert.equal(this.controllers[1].connectCount, 1)
+  }
+
+  "test no loading of module with false shouldLoad"() {
+    this.application.load(this.definitions)
+
+    this.assert.equal(this.controllers.length, 2)
+    this.application.load({ controllerConstructor: DController, identifier: "d" })
+    this.assert.equal(this.controllers.length, 2)
   }
 
   get controllers() {


### PR DESCRIPTION
If you have controllers that are only relevant under certain environmental conditions – like user agent, native, global settings – and caching prevents you from removing them from the DOM, you can use shouldLoad to prevent them from being loaded regardless.