### PR TITLE
Add element and target attribute change callbacks

### DIFF
--- a/docs/reference/lifecycle_callbacks.md
+++ b/docs/reference/lifecycle_callbacks.md
@@ -28,6 +28,9 @@ Method       | Invoked by Stimulus…
 initialize() | Once, when the controller is first instantiated
 [name]TargetConnected(target: Element) | Anytime a target is connected to the DOM
 connect()    | Anytime the controller is connected to the DOM
+attributeChanged(attributeName: string, oldValue: string | null, newValue: string | null) | Anytime the controller element's attributes change
+[name]TargetAttributeChanged(target: Element, attributeName: string, oldValue: string | null, newValue: string | null) | Anytime a target element's attributes change
+disconnect() | Anytime the controller is disconnected from the DOM
 [name]TargetDisconnected(target: Element) | Anytime a target is disconnected from the DOM
 disconnect() | Anytime the controller is disconnected from the DOM
 

--- a/src/tests/controllers/log_controller.ts
+++ b/src/tests/controllers/log_controller.ts
@@ -12,11 +12,21 @@ export type ActionLogEntry = {
   passive: boolean
 }
 
+export type MutationLogEntry = {
+  attributeName: string,
+  controller: Controller
+  identifier: string
+  newValue: string | null,
+  oldValue: string | null,
+}
+
 export class LogController extends Controller {
   static actionLog: ActionLogEntry[] = []
   initializeCount = 0
   connectCount = 0
   disconnectCount = 0
+  attributeChangedCount = 0
+  mutationLog: MutationLogEntry[] = []
 
   initialize() {
     this.initializeCount++
@@ -28,6 +38,10 @@ export class LogController extends Controller {
 
   disconnect() {
     this.disconnectCount++
+  }
+
+  attributeChanged(attributeName: string, oldValue: string | null, newValue: string | null) {
+    this.recordMutation(attributeName, oldValue, newValue)
   }
 
   log(event: ActionEvent) {
@@ -70,6 +84,17 @@ export class LogController extends Controller {
       params: event.params,
       defaultPrevented: event.defaultPrevented,
       passive: passive || false
+    })
+  }
+
+  private recordMutation(attributeName: string, oldValue: string | null, newValue: string | null) {
+    this.attributeChangedCount++
+    this.mutationLog.push({
+      attributeName,
+      oldValue,
+      newValue,
+      controller: this,
+      identifier: this.identifier,
     })
   }
 }

--- a/src/tests/controllers/target_controller.ts
+++ b/src/tests/controllers/target_controller.ts
@@ -9,9 +9,9 @@ class BaseTargetController extends Controller {
 }
 
 export class TargetController extends BaseTargetController {
-  static classes = [ "connected", "disconnected" ]
+  static classes = [ "connected", "disconnected", "attributeChanged" ]
   static targets = [ "beta", "input", "recursive" ]
-  static values = { inputTargetConnectedCallCount: Number, inputTargetDisconnectedCallCount: Number, recursiveTargetConnectedCallCount: Number, recursiveTargetDisconnectedCallCount: Number }
+  static values = { inputTargetConnectedCallCount: Number, inputTargetDisconnectedCallCount: Number, recursiveTargetConnectedCallCount: Number, recursiveTargetDisconnectedCallCount: Number, betaTargetAttributeChangedCallCountValue: Number }
 
   betaTarget!: Element | null
   betaTargets!: Element[]
@@ -23,22 +23,31 @@ export class TargetController extends BaseTargetController {
 
   hasConnectedClass!: boolean
   hasDisconnectedClass!: boolean
+  hasAttributeChangedClass!: boolean
   connectedClass!: string
   disconnectedClass!: string
+  attributeChangedClass!: string
 
   inputTargetConnectedCallCountValue = 0
   inputTargetDisconnectedCallCountValue = 0
+  betaTargetAttributeChangedCallCountValue = 0
   recursiveTargetConnectedCallCountValue = 0
   recursiveTargetDisconnectedCallCountValue = 0
 
-  inputTargetConnected(element: Element) {
-    if (this.hasConnectedClass) element.classList.add(this.connectedClass)
+  inputTargetConnected(target: Element) {
+    if (this.hasConnectedClass) target.classList.add(this.connectedClass)
     this.inputTargetConnectedCallCountValue++
   }
 
-  inputTargetDisconnected(element: Element) {
-    if (this.hasDisconnectedClass) element.classList.add(this.disconnectedClass)
+  inputTargetDisconnected(target: Element) {
+    if (this.hasDisconnectedClass) target.classList.add(this.disconnectedClass)
     this.inputTargetDisconnectedCallCountValue++
+  }
+
+  betaTargetAttributeChanged(target: Element, attributeName: string, ...args: any[]) {
+    if (this.hasAttributeChangedClass) target.classList.add(this.attributeChangedClass)
+    this.betaTargetAttributeChangedCallCountValue++
+    target.setAttribute(attributeName, args.join(","))
   }
 
   recursiveTargetConnected(element: Element) {

--- a/src/tests/modules/core/lifecycle_tests.ts
+++ b/src/tests/modules/core/lifecycle_tests.ts
@@ -28,6 +28,38 @@ export default class LifecycleTests extends LogControllerTestCase {
     this.assert.equal(controller.disconnectCount, 1)
   }
 
+  async "test Controller#attributeChanged called when element changes an attribute"() {
+    const controller = this.controller
+
+    this.assert.equal(controller.attributeChangedCount, 0)
+
+    await this.setElementAttribute(this.controller.element, "data-changed", "new-value")
+
+    const lastMutation = controller.mutationLog.pop()
+    this.assert.equal(controller.attributeChangedCount, 1)
+    this.assert.equal(lastMutation?.attributeName, "data-changed")
+    this.assert.equal(lastMutation?.oldValue, null)
+    this.assert.equal(lastMutation?.newValue, "new-value")
+  }
+
+  async "test Controller#attributeChanged not called when descendant changes an attribute"() {
+    const controller = this.controller
+    this.controllerElement.insertAdjacentHTML("beforeend", `<div id="child"></div>`)
+    const element = controller.element.querySelector("#child")
+
+    this.assert.equal(controller.attributeChangedCount, 0)
+
+    await this.setElementAttribute(element!, "data-changed", "new-value")
+
+    this.assert.equal(controller.attributeChangedCount, 0)
+    this.assert.equal(controller.mutationLog.length, 0)
+  }
+
+  async setElementAttribute(element: Element, attributeName: string, value: string) {
+    element.setAttribute(attributeName, value)
+    await this.nextFrame
+  }
+
   async reconnectControllerElement() {
     await this.disconnectControllerElement()
     await this.connectControllerElement()

--- a/src/tests/modules/core/target_tests.ts
+++ b/src/tests/modules/core/target_tests.ts
@@ -3,7 +3,7 @@ import { TargetController } from "../../controllers/target_controller"
 
 export default class TargetTests extends ControllerTestCase(TargetController) {
   fixtureHTML = `
-    <div data-controller="${this.identifier}" data-${this.identifier}-connected-class="connected" data-${this.identifier}-disconnected-class="disconnected">
+    <div data-controller="${this.identifier}" data-${this.identifier}-connected-class="connected" data-${this.identifier}-disconnected-class="disconnected" data-${this.identifier}-attribute-changed-class="changed">
       <div data-${this.identifier}-target="alpha" id="alpha1"></div>
       <div data-${this.identifier}-target="alpha" id="alpha2"></div>
       <div data-${this.identifier}-target="beta" id="beta1">
@@ -63,14 +63,14 @@ export default class TargetTests extends ControllerTestCase(TargetController) {
     this.assert.throws(() => this.controller.betaTarget)
   }
 
-  "test target connected callback fires after initialize() and when calling connect()"() {
+  "test [target]Connected callback fires after initialize() and when calling connect()"() {
     const connectedInputs = this.controller.inputTargets.filter(target => target.classList.contains("connected"))
 
     this.assert.equal(connectedInputs.length, 1)
     this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 1)
   }
 
-  async "test target connected callback when element is inserted"() {
+  async "test [target]Connected callback when element is inserted"() {
     const connectedInput = document.createElement("input")
     connectedInput.setAttribute(`data-${this.controller.identifier}-target`, "input")
 
@@ -84,7 +84,7 @@ export default class TargetTests extends ControllerTestCase(TargetController) {
     this.assert.ok(connectedInput.isConnected, "element is present in document")
   }
 
-  async "test target connected callback when present element adds the target attribute"() {
+  async "test [target]Connected callback when present element adds the target attribute"() {
     const element = this.findElement("#alpha1")
 
     this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 1)
@@ -97,7 +97,7 @@ export default class TargetTests extends ControllerTestCase(TargetController) {
     this.assert.ok(element.isConnected, "element is still present in document")
   }
 
-  async "test target connected callback when element adds a token to an existing target attribute"() {
+  async "test [target]Connected callback when element adds a token to an existing target attribute"() {
     const element = this.findElement("#alpha1")
 
     this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 1)
@@ -110,7 +110,7 @@ export default class TargetTests extends ControllerTestCase(TargetController) {
     this.assert.ok(element.isConnected, "element is still present in document")
   }
 
-  async "test target disconnected callback fires when calling disconnect() on the controller"() {
+  async "test [target]Disconnected callback fires when calling disconnect() on the controller"() {
     this.assert.equal(this.controller.inputTargets.filter(target => target.classList.contains("disconnected")).length, 0)
     this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 0)
 
@@ -121,7 +121,7 @@ export default class TargetTests extends ControllerTestCase(TargetController) {
     this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 1)
   }
 
-  async "test target disconnected callback when element is removed"() {
+  async "test [target]Disconnected callback when element is removed"() {
     const disconnectedInput = this.findElement("#input1")
 
     this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 0)
@@ -135,7 +135,7 @@ export default class TargetTests extends ControllerTestCase(TargetController) {
     this.assert.notOk(disconnectedInput.isConnected, "element is not present in document")
   }
 
-  async "test target disconnected callback when an element present in the document removes the target attribute"() {
+  async "test [target]Disconnected callback when an element present in the document removes the target attribute"() {
     const element = this.findElement("#input1")
 
     this.assert.equal(this.controller.inputTargetDisconnectedCallCountValue, 0)
@@ -149,7 +149,7 @@ export default class TargetTests extends ControllerTestCase(TargetController) {
     this.assert.ok(element.isConnected, "element is still present in document")
   }
 
-  async "test target disconnected(), then connected() callback fired when the target name is present after the attribute change"() {
+  async "test [target]Disconnected, then [target]Connected callback fired when the target name is present after the attribute change"() {
     const element = this.findElement("#input1")
 
     this.assert.equal(this.controller.inputTargetConnectedCallCountValue, 1)
@@ -174,5 +174,33 @@ export default class TargetTests extends ControllerTestCase(TargetController) {
     this.assert.ok(!!this.fixtureElement.querySelector("#recursive2"))
     this.assert.equal(this.controller.recursiveTargetConnectedCallCountValue, 1)
     this.assert.equal(this.controller.recursiveTargetDisconnectedCallCountValue, 0)
+  }
+
+  async "test calls [target]AttributeChanged callback when target changes an attribute"() {
+    const beta = this.findElement("#beta1")
+
+    this.assert.equal(this.controller.betaTargetAttributeChangedCallCountValue, 0)
+    this.assert.notOk(beta.classList.contains("changed"), `expected "${beta.className}" not to contain "changed"`)
+
+    beta.setAttribute("data-changed", "newValue")
+    await this.nextFrame
+
+    this.assert.equal(beta.getAttribute("data-changed"), ",newValue", `expected [data-changed] to capture the callback arguments`)
+    this.assert.equal(this.controller.betaTargetAttributeChangedCallCountValue, 1)
+    this.assert.ok(beta.classList.contains("changed"), `expected "${beta.className}" to contain "changed"`)
+  }
+
+  async "test does not call [target]AttributeChanged callback when a descendant's attribute changes"() {
+    const beta = this.findElement("#beta1")
+    const gamma = this.findElement("#gamma1")
+
+    this.assert.equal(this.controller.betaTargetAttributeChangedCallCountValue, 0)
+    this.assert.notOk(beta.classList.contains("changed"), `expected "${beta.className}" not to contain "changed"`)
+
+    gamma.setAttribute("data-changed", "value")
+    await this.nextFrame
+
+    this.assert.equal(this.controller.betaTargetAttributeChangedCallCountValue, 0)
+    this.assert.notOk(beta.classList.contains("changed"), `expected "${beta.className}" not to contain "changed"`)
   }
 }


### PR DESCRIPTION
# Caveat

I still believe that [declaring mutation callbacks](https://github.com/hotwired/stimulus/pull/397) in the same style as event Action Routing is more aligned with Stimulus idioms and has the same self-documenting aspirations. With that being said, I think investigating more generic Controller callbacks could serve as an interesting exercise.

# Changes

Closes https://github.com/hotwired/stimulus/issues/445

---

Implement [attributeChange][] callbacks for both a controller's element
and its targets.

The `attributeChanged` and `[name]TargetAttributeChanged` callback
signatures are styled after the Custom Element's
`attributeChangedCallback`. The target variations accept the target
element as the first argument, but are otherwise the same.

It feels more appropriate to strive for parity in the interface than it
is to yield the underlying [MutationRecord][] to call sites.

[attributeChange]: https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks
[MutationRecord]: https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord