### PR TITLE
Fix package.json module for stimulus package

### DIFF
--- a/packages/stimulus/package.json
+++ b/packages/stimulus/package.json
@@ -10,7 +10,7 @@
     "Sam Stephenson <sstephenson@gmail.com>"
   ],
   "main": "dist/stimulus.js",
-  "module": "dist/stimulus.esm.js",
+  "module": "dist/stimulus.umd.js",
   "files": [
     "dist/stimulus.js",
     "dist/stimulus.umd.js",


### PR DESCRIPTION
It appears that the `stimulus` package (the one published to npm as `stimulus` rather than `@hotwired/stimulus`, has incorrect `module` defined in the `package.json`. The file `stimulus.esm.js` does not exist in the built package.

This causes problem with other packages that still import `stimulus`.