### PR TITLE
Add to handbook doc: ability to override data- attributes for controller, target, action

### DIFF
--- a/docs/handbook/07_installing_stimulus.md
+++ b/docs/handbook/07_installing_stimulus.md
@@ -89,6 +89,27 @@ If you prefer not to use a build system, you can load Stimulus in a `<script typ
 </html>
 ```
 
+## Overriding Attribute Defaults
+In case Stimulus `data-*` attributes conflict with another library in your project, they can be overridden when creating the Stimulus `Application`.
+
+- `data-controller`
+- `data-action`
+- `data-target`
+
+These core Stimulus attributes can be overridden (see: [schema.ts](../../src/core/schema.ts)):
+
+```js
+// src/application.js
+import { Application, defaultSchema } from "@hotwired/stimulus"
+
+const customSchema = {
+  ...defaultSchema,
+  actionAttribute: 'data-stimulus-action'
+}
+
+window.Stimulus = Application.start(document.documentElement, customSchema);
+```
+
 ## Error handling
 
 All calls from Stimulus to your application's code are wrapped in a `try ... catch` block.


### PR DESCRIPTION
# Documentation Changes

I recently encountered an issue where I added Stimulus to a client project and I quickly discovered the `data-action` attribute was already being listened for and conflicting with the stimulus event expectations. Unable to remove that javascript I read some code and learned how to override these attributes. 

To help others who may encounter similar conflicts I'd like to propose adding this process to the Stimulus handbook.

Thanks for your consideration. 