### PR TITLE
Fixing color highlight

### DIFF
--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -23,7 +23,9 @@ You can read and write [HTML data attributes](https://developer.mozilla.org/en-U
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static values = { url: String }
+  static values = {
+    url: String
+  }
 
   connect() {
     fetch(this.urlValue).then(/* … */)


### PR DESCRIPTION
For some reasons, the inline syntax does not work well.

## Before
![Screenshot 2021-11-04 at 11 46 26](https://user-images.githubusercontent.com/8252238/140302176-e40f2769-d59e-4562-afbc-24cdc35fd2b8.png)

## After
![Screenshot 2021-11-04 at 11 42 04](https://user-images.githubusercontent.com/8252238/140302221-89a09284-84cf-4428-9d34-b50e0ca79815.png)

