### PR TITLE
Docs: Fix element where CSS class attribute is set

### DIFF
--- a/docs/handbook/04_designing_for_resilience.md
+++ b/docs/handbook/04_designing_for_resilience.md
@@ -19,10 +19,16 @@ Let's look at how we can progressively enhance our PIN field so that the Copy bu
 
 We'll start by hiding the Copy button in CSS. Then we'll _feature-test_ support for the Clipboard API in our Stimulus controller. If the API is supported, we'll add a class name to the controller element to reveal the button.
 
-Start by adding `class="clipboard-button"` to the button element:
+We start off by adding `data-clipboard-supported-class="clipboard--supported"` to the `div` element that has the `data-controller` attribute:
 
 ```html
-  <button data-action="clipboard#copy" class="clipboard-button" data-clipboard-supported-class="clipboard--supported">Copy to Clipboard</button>
+  <div data-controller="clipboard" data-clipboard-supported-class="clipboard--supported">
+```
+
+Then add `class="clipboard-button"` to the button element:
+
+```html
+  <button data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</button>
 ```
 
 Then add the following styles to `public/main.css`:


### PR DESCRIPTION
The reference clearly (and correctly) says that CSS class attributes must be specified on the same element as the data-controller attribute, but this attribute is set on the button element inside the `data-controller` div in the handbook (https://stimulus.hotwired.dev/handbook/designing-for-resilience#progressively-enhancing-the-pin-field).

Following the handbook in the current state produces this error:
```
Error: Missing attribute "data-clipboard-supported-class"
```