### PR TITLE
Update copy to clipboard tutorial

### DIFF
--- a/docs/handbook/03_building_something_real.md
+++ b/docs/handbook/03_building_something_real.md
@@ -105,19 +105,11 @@ We want a click on the button to invoke the `copy()` method in our controller, s
 > | select            | change        |
 > | textarea          | input         |
 
-We can set a `get` method for our source target so we can easily reference the value:
-
-```js
-  get source() {
-    return this.sourceTarget.value
-  }
-```
-
 Finally, in our `copy()` method, we can select the input field's contents and call the clipboard API:
 
 ```js
   copy() {
-    navigator.clipboard.writeText(this.source)
+    navigator.clipboard.writeText(this.sourceTarget.value)
   }
 ```
 

--- a/docs/handbook/03_building_something_real.md
+++ b/docs/handbook/03_building_something_real.md
@@ -62,7 +62,7 @@ Now add a target definition to the controller so we can access the text field el
 
 ```js
 export default class extends Controller {
-  static targets = ["source"]
+  static targets = [ "source" ]
 
   // ...
 }

--- a/docs/handbook/03_building_something_real.md
+++ b/docs/handbook/03_building_something_real.md
@@ -25,7 +25,7 @@ Open `public/index.html` and replace the contents of `<body>` with a rough sketc
 
 ```html
 <div>
-  PIN: <input type="text" value="1234" readonly>
+  PIN: <input type="text" value="1234" readonly />
   <button>Copy to Clipboard</button>
 </div>
 ```
@@ -36,18 +36,17 @@ Next, create `src/controllers/clipboard_controller.js` and add an empty method `
 
 ```js
 // src/controllers/clipboard_controller.js
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  copy() {
-  }
+  copy() {}
 }
 ```
 
 Then add `data-controller="clipboard"` to the outer `<div>`. Any time this attribute appears on an element, Stimulus will connect an instance of our controller:
 
 ```html
-<div data-controller="clipboard">
+<div data-controller="clipboard"></div>
 ```
 
 ## Defining the Target
@@ -55,14 +54,14 @@ Then add `data-controller="clipboard"` to the outer `<div>`. Any time this attri
 We'll need a reference to the text field so we can select its contents before invoking the clipboard API. Add `data-clipboard-target="source"` to the text field:
 
 ```html
-  PIN: <input data-clipboard-target="source" type="text" value="1234" readonly>
+PIN: <input data-clipboard-target="source" type="text" value="1234" readonly />
 ```
 
 Now add a target definition to the controller so we can access the text field element as `this.sourceTarget`:
 
 ```js
 export default class extends Controller {
-  static targets = [ "source" ]
+  static targets = ["source"];
 
   // ...
 }
@@ -72,9 +71,9 @@ export default class extends Controller {
 >
 > When Stimulus loads your controller class, it looks for target name strings in a static array called `targets`. For each target name in the array, Stimulus adds three new properties to your controller. Here, our `"source"` target name becomes the following properties:
 >
-> * `this.sourceTarget` evaluates to the first `source` target in your controller's scope. If there is no `source` target, accessing the property throws an error.
-> * `this.sourceTargets` evaluates to an array of all `source` targets in the controller's scope.
-> * `this.hasSourceTarget` evaluates to `true` if there is a `source` target or `false` if not.
+> - `this.sourceTarget` evaluates to the first `source` target in your controller's scope. If there is no `source` target, accessing the property throws an error.
+> - `this.sourceTargets` evaluates to an array of all `source` targets in the controller's scope.
+> - `this.hasSourceTarget` evaluates to `true` if there is a `source` target or `false` if not.
 >
 > You can read more about targets in the [reference documentation](/reference/targets).
 
@@ -85,7 +84,7 @@ Now we're ready to hook up the Copy button.
 We want a click on the button to invoke the `copy()` method in our controller, so we'll add `data-action="clipboard#copy"`:
 
 ```html
-  <button data-action="clipboard#copy">Copy to Clipboard</button>
+<button data-action="clipboard#copy">Copy to Clipboard</button>
 ```
 
 > ### Common Events Have a Shorthand Action Notation
@@ -94,23 +93,30 @@ We want a click on the button to invoke the `copy()` method in our controller, s
 >
 > Certain other elements have default events, too. Here's the full list:
 >
-> Element           | Default Event
-> ----------------- | -------------
-> a                 | click
-> button            | click
-> details           | toggle
-> form              | submit
-> input             | input
-> input type=submit | click
-> select            | change
-> textarea          | input
+> | Element           | Default Event |
+> | ----------------- | ------------- |
+> | a                 | click         |
+> | button            | click         |
+> | details           | toggle        |
+> | form              | submit        |
+> | input             | input         |
+> | input type=submit | click         |
+> | select            | change        |
+> | textarea          | input         |
+
+We can set a `get` method for our source target so we can easily reference the value:
+
+```js
+  get source() {
+    return this.sourceTarget.value
+  }
+```
 
 Finally, in our `copy()` method, we can select the input field's contents and call the clipboard API:
 
 ```js
   copy() {
-    this.sourceTarget.select()
-    document.execCommand("copy")
+    navigator.clipboard.writeText(this.source);
   }
 ```
 
@@ -128,8 +134,11 @@ Let's go ahead and add another PIN to the page. Copy and paste the `<div>` so th
 
 ```html
 <div data-controller="clipboard">
-  PIN: <input data-clipboard-target="source" type="text" value="3737" readonly>
-  <button data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</button>
+  PIN:
+  <input data-clipboard-target="source" type="text" value="3737" readonly />
+  <button data-action="clipboard#copy" class="clipboard-button">
+    Copy to Clipboard
+  </button>
 </div>
 ```
 
@@ -141,8 +150,11 @@ Now let's add one more PIN field. This time we'll use a Copy _link_ instead of a
 
 ```html
 <div data-controller="clipboard">
-  PIN: <input data-clipboard-target="source" type="text" value="3737" readonly>
-  <a href="#" data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</a>
+  PIN:
+  <input data-clipboard-target="source" type="text" value="3737" readonly />
+  <a href="#" data-action="clipboard#copy" class="clipboard-button"
+    >Copy to Clipboard</a
+  >
 </div>
 ```
 
@@ -161,7 +173,7 @@ Note that in this case, clicking the link will also cause the browser to follow 
 Similarly, our `source` target need not be an `<input type="text">`. The controller only expects it to have a `value` property and a `select()` method. That means we can use a `<textarea>` instead:
 
 ```html
-  PIN: <textarea data-clipboard-target="source" readonly>3737</textarea>
+PIN: <textarea data-clipboard-target="source" readonly>3737</textarea>
 ```
 
 ## Wrap-Up and Next Steps

--- a/docs/handbook/03_building_something_real.md
+++ b/docs/handbook/03_building_something_real.md
@@ -55,7 +55,7 @@ Then add `data-controller="clipboard"` to the outer `<div>`. Any time this attri
 We'll need a reference to the text field so we can select its contents before invoking the clipboard API. Add `data-clipboard-target="source"` to the text field:
 
 ```html
-PIN: <input data-clipboard-target="source" type="text" value="1234" readonly>
+  PIN: <input data-clipboard-target="source" type="text" value="1234" readonly>
 ```
 
 Now add a target definition to the controller so we can access the text field element as `this.sourceTarget`:
@@ -136,9 +136,7 @@ Let's go ahead and add another PIN to the page. Copy and paste the `<div>` so th
 ```html
 <div data-controller="clipboard">
   PIN: <input data-clipboard-target="source" type="text" value="3737" readonly>
-  <button data-action="clipboard#copy" class="clipboard-button">
-    Copy to Clipboard
-  </button>
+  <button data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</button>
 </div>
 ```
 
@@ -150,11 +148,8 @@ Now let's add one more PIN field. This time we'll use a Copy _link_ instead of a
 
 ```html
 <div data-controller="clipboard">
-  PIN:
-  <input data-clipboard-target="source" type="text" value="3737" readonly />
-  <a href="#" data-action="clipboard#copy" class="clipboard-button"
-    >Copy to Clipboard</a
-  >
+  PIN: <input data-clipboard-target="source" type="text" value="3737" readonly>
+  <a href="#" data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</a>
 </div>
 ```
 

--- a/docs/handbook/03_building_something_real.md
+++ b/docs/handbook/03_building_something_real.md
@@ -25,7 +25,7 @@ Open `public/index.html` and replace the contents of `<body>` with a rough sketc
 
 ```html
 <div>
-  PIN: <input type="text" value="1234" readonly />
+  PIN: <input type="text" value="1234" readonly>
   <button>Copy to Clipboard</button>
 </div>
 ```
@@ -36,17 +36,18 @@ Next, create `src/controllers/clipboard_controller.js` and add an empty method `
 
 ```js
 // src/controllers/clipboard_controller.js
-import { Controller } from "@hotwired/stimulus";
+import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  copy() {}
+  copy() {
+  }
 }
 ```
 
 Then add `data-controller="clipboard"` to the outer `<div>`. Any time this attribute appears on an element, Stimulus will connect an instance of our controller:
 
 ```html
-<div data-controller="clipboard"></div>
+<div data-controller="clipboard">
 ```
 
 ## Defining the Target
@@ -54,14 +55,14 @@ Then add `data-controller="clipboard"` to the outer `<div>`. Any time this attri
 We'll need a reference to the text field so we can select its contents before invoking the clipboard API. Add `data-clipboard-target="source"` to the text field:
 
 ```html
-PIN: <input data-clipboard-target="source" type="text" value="1234" readonly />
+PIN: <input data-clipboard-target="source" type="text" value="1234" readonly>
 ```
 
 Now add a target definition to the controller so we can access the text field element as `this.sourceTarget`:
 
 ```js
 export default class extends Controller {
-  static targets = ["source"];
+  static targets = ["source"]
 
   // ...
 }
@@ -71,9 +72,9 @@ export default class extends Controller {
 >
 > When Stimulus loads your controller class, it looks for target name strings in a static array called `targets`. For each target name in the array, Stimulus adds three new properties to your controller. Here, our `"source"` target name becomes the following properties:
 >
-> - `this.sourceTarget` evaluates to the first `source` target in your controller's scope. If there is no `source` target, accessing the property throws an error.
-> - `this.sourceTargets` evaluates to an array of all `source` targets in the controller's scope.
-> - `this.hasSourceTarget` evaluates to `true` if there is a `source` target or `false` if not.
+> * `this.sourceTarget` evaluates to the first `source` target in your controller's scope. If there is no `source` target, accessing the property throws an error.
+> * `this.sourceTargets` evaluates to an array of all `source` targets in the controller's scope.
+> * `this.hasSourceTarget` evaluates to `true` if there is a `source` target or `false` if not.
 >
 > You can read more about targets in the [reference documentation](/reference/targets).
 
@@ -84,7 +85,7 @@ Now we're ready to hook up the Copy button.
 We want a click on the button to invoke the `copy()` method in our controller, so we'll add `data-action="clipboard#copy"`:
 
 ```html
-<button data-action="clipboard#copy">Copy to Clipboard</button>
+  <button data-action="clipboard#copy">Copy to Clipboard</button>
 ```
 
 > ### Common Events Have a Shorthand Action Notation
@@ -116,7 +117,7 @@ Finally, in our `copy()` method, we can select the input field's contents and ca
 
 ```js
   copy() {
-    navigator.clipboard.writeText(this.source);
+    navigator.clipboard.writeText(this.source)
   }
 ```
 
@@ -134,8 +135,7 @@ Let's go ahead and add another PIN to the page. Copy and paste the `<div>` so th
 
 ```html
 <div data-controller="clipboard">
-  PIN:
-  <input data-clipboard-target="source" type="text" value="3737" readonly />
+  PIN: <input data-clipboard-target="source" type="text" value="3737" readonly>
   <button data-action="clipboard#copy" class="clipboard-button">
     Copy to Clipboard
   </button>
@@ -173,7 +173,7 @@ Note that in this case, clicking the link will also cause the browser to follow 
 Similarly, our `source` target need not be an `<input type="text">`. The controller only expects it to have a `value` property and a `select()` method. That means we can use a `<textarea>` instead:
 
 ```html
-PIN: <textarea data-clipboard-target="source" readonly>3737</textarea>
+  PIN: <textarea data-clipboard-target="source" readonly>3737</textarea>
 ```
 
 ## Wrap-Up and Next Steps

--- a/docs/handbook/04_designing_for_resilience.md
+++ b/docs/handbook/04_designing_for_resilience.md
@@ -51,7 +51,7 @@ First we'll add the `data-clipboard-supported-class` attribute inside the contro
 
 This will let us control the specific CSS class in the HTML, so our controller becomes even more easily adaptable to different CSS approaches. The specific class added like this can be accessed via `this.supportedClass`.
 
-Now add a `connect()` method to the controller which will add a class name to the controller's element when the API is supported:
+Now add a `connect()` method to the controller which will add a class name to the controller's element when the user agent has permission to write to the clipboard:
 
 ```js
   connect() {

--- a/docs/handbook/04_designing_for_resilience.md
+++ b/docs/handbook/04_designing_for_resilience.md
@@ -22,13 +22,18 @@ We'll start by hiding the Copy button in CSS. Then we'll _feature-test_ support 
 We start off by adding `data-clipboard-supported-class="clipboard--supported"` to the `div` element that has the `data-controller` attribute:
 
 ```html
-  <div data-controller="clipboard" data-clipboard-supported-class="clipboard--supported">
+<div
+  data-controller="clipboard"
+  data-clipboard-supported-class="clipboard--supported"
+></div>
 ```
 
 Then add `class="clipboard-button"` to the button element:
 
 ```html
-  <button data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</button>
+<button data-action="clipboard#copy" class="clipboard-button">
+  Copy to Clipboard
+</button>
 ```
 
 Then add the following styles to `public/main.css`:
@@ -55,9 +60,11 @@ Now add a `connect()` method to the controller which will add a class name to th
 
 ```js
   connect() {
-    if (document.queryCommandSupported("copy")) {
-      this.element.classList.add(this.supportedClass)
-    }
+    navigator.permissions.query({ name: "clipboard-write" }).then((result) => {
+      if (result.state === "granted") {
+        this.element.classList.add(this.supportedClass);
+      }
+    });
   }
 ```
 

--- a/docs/handbook/04_designing_for_resilience.md
+++ b/docs/handbook/04_designing_for_resilience.md
@@ -22,13 +22,13 @@ We'll start by hiding the Copy button in CSS. Then we'll _feature-test_ support 
 We start off by adding `data-clipboard-supported-class="clipboard--supported"` to the `div` element that has the `data-controller` attribute:
 
 ```html
-<div data-controller="clipboard" data-clipboard-supported-class="clipboard--supported">
+  <div data-controller="clipboard" data-clipboard-supported-class="clipboard--supported">
 ```
 
 Then add `class="clipboard-button"` to the button element:
 
 ```html
-<button data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</button>
+  <button data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</button>
 ```
 
 Then add the following styles to `public/main.css`:

--- a/docs/handbook/04_designing_for_resilience.md
+++ b/docs/handbook/04_designing_for_resilience.md
@@ -22,18 +22,13 @@ We'll start by hiding the Copy button in CSS. Then we'll _feature-test_ support 
 We start off by adding `data-clipboard-supported-class="clipboard--supported"` to the `div` element that has the `data-controller` attribute:
 
 ```html
-<div
-  data-controller="clipboard"
-  data-clipboard-supported-class="clipboard--supported"
-></div>
+<div data-controller="clipboard" data-clipboard-supported-class="clipboard--supported">
 ```
 
 Then add `class="clipboard-button"` to the button element:
 
 ```html
-<button data-action="clipboard#copy" class="clipboard-button">
-  Copy to Clipboard
-</button>
+<button data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</button>
 ```
 
 Then add the following styles to `public/main.css`:


### PR DESCRIPTION
I was running into a few warnings about `Document.execCommand` being [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand):
![image](https://user-images.githubusercontent.com/19216177/140789319-b2b6e3f8-4cd1-4d24-ab74-dd0ffab9ae12.png)

These changes update the docs to use the [`Navigator`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard) interface to implement the copy to clipboard method.