### PR TITLE
Typo in 06_working_with_external_resources.md

### DIFF
--- a/docs/handbook/06_working_with_external_resources.md
+++ b/docs/handbook/06_working_with_external_resources.md
@@ -205,7 +205,7 @@ export default class extends Controller {
 We could even destruct the params to just get the URL parameter:
 
 ```js
-  load({ params: url }) {
+  load({ params: { url } }) {
     fetch(url)
       .then(response => response.text())
       .then(html => this.element.innerHTML = html)

--- a/docs/reference/controllers.md
+++ b/docs/reference/controllers.md
@@ -191,7 +191,7 @@ So when the `Clipboard#copy` action is invoked, the `Effects#flash` action will 
 
 ```js
 class EffectsController extends Controller {
-  flash({ detail: content }) {
+  flash({ detail: { content } }) {
     console.log(content) // 1234
   }
 }


### PR DESCRIPTION
`params: url` does not destructure