### PR TITLE
move shouldLoad check from register to load function

### DIFF
--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -43,16 +43,18 @@ export class Application implements ErrorHandler {
   }
 
   register(identifier: string, controllerConstructor: ControllerConstructor) {
-    if ((controllerConstructor as any).shouldLoad) {
-      this.load({ identifier, controllerConstructor })
-    }
+    this.load({ identifier, controllerConstructor })
   }
 
   load(...definitions: Definition[]): void
   load(definitions: Definition[]): void
   load(head: Definition | Definition[], ...rest: Definition[]) {
     const definitions = Array.isArray(head) ? head : [head, ...rest]
-    definitions.forEach(definition => this.router.loadDefinition(definition))
+    definitions.forEach(definition => {
+      if ((definition.controllerConstructor as any).shouldLoad) {
+        this.router.loadDefinition(definition)
+      }
+    })
   }
 
   unload(...identifiers: string[]): void


### PR DESCRIPTION
The current implementation of [shouldLoad](https://stimulus.hotwired.dev/reference/controllers#preventing-registration-based-on-environmental-factors) lives in the `register` function. This function is used to manually register individual controllers. Another option to register controllers is to use the [`load`](https://github.com/hotwired/stimulus/blob/a227d628a488b9acd485a547cfa5f27a8267ad9e/src/core/application.ts#L51-L56) function. This has been the advertise way of loading controllers with the webpacker helpers and [remains the recommended solution.](https://github.com/hotwired/stimulus-webpack-helpers)

But the `shouldLoad` function is only used in `register`  function not in `load`. This PR move the `shouldLoad` check from `register` down to `load`.
