### PR TITLE
Allow action params for global events

### DIFF
--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -30,26 +30,17 @@ export class Action {
     return `${this.eventName}${eventNameSuffix}->${this.identifier}#${this.methodName}`
   }
 
-  get params(): object {
-    if (this.eventTarget instanceof Element) {
-      return this.getParamsFromEventTargetAttributes(this.eventTarget)
-    } else {
-      return {}
-    }
-  }
-
-  private getParamsFromEventTargetAttributes(eventTarget: Element): {[key: string]: any} {
-    const params = {}
+  get params() {
+    const params:{ [key: string]: any } = {}
     const pattern = new RegExp(`^data-${this.identifier}-(.+)-param$`)
-    const attributes = Array.from(eventTarget.attributes)
 
-    attributes.forEach(({ name, value }: { name: string, value: string }) => {
+    for (const { name, value } of Array.from(this.element.attributes)) {
       const match = name.match(pattern)
       const key = match && match[1]
       if (key) {
-        Object.assign(params, { [camelize(key)]: typecast(value) })
+        params[camelize(key)]= typecast(value)
       }
-    })
+    }
     return params
   }
 

--- a/src/tests/modules/core/action_params_tests.ts
+++ b/src/tests/modules/core/action_params_tests.ts
@@ -16,6 +16,7 @@ export default class ActionParamsTests extends LogControllerTestCase {
         <div id="nested"></div>
       </button>
     </div>
+    <div id="outside"></div>
   `
   expectedParamsForC = {
     id: 123,
@@ -32,6 +33,16 @@ export default class ActionParamsTests extends LogControllerTestCase {
     this.actionValue = "click->c#log"
     await this.nextFrame
     await this.triggerEvent(this.buttonElement, "click")
+
+    this.assertActions(
+      { identifier: "c", params: this.expectedParamsForC },
+    )
+  }
+
+  async "test global event return element params where the action is defined"() {
+    this.actionValue = "keydown@window->c#log"
+    await this.nextFrame
+    await this.triggerEvent("#outside", "keydown")
 
     this.assertActions(
       { identifier: "c", params: this.expectedParamsForC },


### PR DESCRIPTION
Ping @adrienpoly since you implemented the original version and you might have some insight why you used the event target rather than the element.