### PR TITLE
Remove unnecessary `clipboard-button` class from Chapter 3 examples

### DIFF
--- a/docs/handbook/03_building_something_real.md
+++ b/docs/handbook/03_building_something_real.md
@@ -128,7 +128,7 @@ Let's go ahead and add another PIN to the page. Copy and paste the `<div>` so th
 ```html
 <div data-controller="clipboard">
   PIN: <input data-clipboard-target="source" type="text" value="3737" readonly>
-  <button data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</button>
+  <button data-action="clipboard#copy">Copy to Clipboard</button>
 </div>
 ```
 
@@ -141,7 +141,7 @@ Now let's add one more PIN field. This time we'll use a Copy _link_ instead of a
 ```html
 <div data-controller="clipboard">
   PIN: <input data-clipboard-target="source" type="text" value="3737" readonly>
-  <a href="#" data-action="clipboard#copy" class="clipboard-button">Copy to Clipboard</a>
+  <a href="#" data-action="clipboard#copy">Copy to Clipboard</a>
 </div>
 ```
 


### PR DESCRIPTION
Two of the examples in Chapter 3 have a `clipboard-button` class that does not appear to be required, as it is only introduced and used in Chapter 4.