### PR TITLE
Fire Value Change Callbacks consistently

### DIFF
--- a/src/core/value_observer.ts
+++ b/src/core/value_observer.ts
@@ -14,11 +14,11 @@ export class ValueObserver implements StringMapObserverDelegate {
     this.receiver = receiver
     this.stringMapObserver = new StringMapObserver(this.element, this)
     this.valueDescriptorMap = (this.controller as any).valueDescriptorMap
-    this.invokeChangedCallbacksForDefaultValues()
   }
 
   start() {
     this.stringMapObserver.start()
+    this.invokeChangedCallbacksForDefaultValues()
   }
 
   stop() {

--- a/src/tests/controllers/default_value_controller.ts
+++ b/src/tests/controllers/default_value_controller.ts
@@ -66,4 +66,17 @@ export class DefaultValueController extends Controller {
   hasDefaultObjectPersonValue!: boolean
   defaultObjectOverrideValue!: object
   hasDefaultObjectOverrideValue!: boolean
+  lifecycleCallbacks: string[] = []
+
+  initialize() {
+    this.lifecycleCallbacks.push("initialize")
+  }
+
+  connect() {
+    this.lifecycleCallbacks.push("connect")
+  }
+
+  defaultBooleanValueChanged() {
+    this.lifecycleCallbacks.push("defaultBooleanValueChanged")
+  }
 }

--- a/src/tests/modules/core/default_value_tests.ts
+++ b/src/tests/modules/core/default_value_tests.ts
@@ -171,6 +171,10 @@ export default class DefaultValueTests extends ControllerTestCase(DefaultValueCo
     this.assert.ok(this.controller.hasDefaultObjectOverrideValue)
   }
 
+  "test [name]ValueChanged callbacks fire after initialize and before connect"() {
+    this.assert.deepEqual(this.controller.lifecycleCallbacks, ["initialize", "defaultBooleanValueChanged", "connect"])
+  }
+
   has(name: string) {
     return this.element.hasAttribute(this.attr(name))
   }


### PR DESCRIPTION
[Closes 490][]

According to the [Change callbacks][] documentation:

> Stimulus invokes each change callback after the controller is
> initialized and again any time its associated data attribute changes.
> This includes changes as a result of assignment to the value’s setter.

Prior to this change, this was true for all value change callbacks
_except_ for those that declare defaults.

This change moves the
`ValueObserver.invokeChangedCallbacksForDefaultValues()` invocation out
of the constructor and into the `ValueObserver.start()` call, which is
invoked by [Context.connect][], which is invoked _after_ the
[Context.constructor][].

[Closes 490]: https://github.com/hotwired/stimulus/issues/490
[Change callbacks]: https://stimulus.hotwired.dev/reference/values#change-callbacks
[Context.constructor]: https://github.com/hotwired/stimulus/blob/5149adf287425597306d7871b1820795d7af1e66/src/core/context.ts#L20-L34
[Context.connect]: https://github.com/hotwired/stimulus/blob/5149adf287425597306d7871b1820795d7af1e66/src/core/context.ts#L36-L47