### PR TITLE
Fix param example typo

### DIFF
--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -184,7 +184,7 @@ All parameters are automatically typecast to either a `Number`, `String`, `Objec
 
 Data attribute                                  | Param                | Type
 ----------------------------------------------- | -------------------- | --------
-`data-item-id-param="12345"`                    | `123`                | Number
+`data-item-id-param="12345"`                    | `12345`              | Number
 `data-item-url-param="/votes"`                  | `"/votes"`           | String
 `data-item-payload-param='{"value":"1234567"}'` | `{ value: 1234567 }` | Object
 `data-item-active-param="true"`                 | `true`               | Boolean


### PR DESCRIPTION
In **Action Parameters** table **item-id** attribute value doesn't match param value.

Cheers
🍷 