### PR TITLE
Fix typo in reference

### DIFF
--- a/docs/reference/controllers.md
+++ b/docs/reference/controllers.md
@@ -164,7 +164,7 @@ application.register("unloadable", UnloadableController)
 
 ## Cross-Controller Coordination With Events
 
-If you need controllers to communicate with each other, you should use events. The `Controller` class has a convenience method called `dispatch` that makes this easier. It takes an `eventName` as the first argument, which is then automatically prefixed with the name of the controller seperated by a colon. The payload is held in `detail`. It works like this:
+If you need controllers to communicate with each other, you should use events. The `Controller` class has a convenience method called `dispatch` that makes this easier. It takes an `eventName` as the first argument, which is then automatically prefixed with the name of the controller separated by a colon. The payload is held in `detail`. It works like this:
 
 ```js
 class ClipboardController extends Controller {


### PR DESCRIPTION
Fixes a small typo in the otherwise delightful [Cross-Controller Coordination with Events](https://stimulus.hotwired.dev/reference/controllers#cross-controller-coordination-with-events) section of the reference.

Happy Friday 🎈 