### PR TITLE
Add `identifier` to documented controller's property

### DIFF
--- a/docs/reference/controllers.md
+++ b/docs/reference/controllers.md
@@ -23,6 +23,7 @@ Every controller belongs to a Stimulus `Application` instance and is associated 
 
 * application, via the `this.application` property
 * HTML element, via the `this.element` property
+* identifier, via the `this.identifier` property
 
 ## Modules
 


### PR DESCRIPTION
* When preparing https://github.com/hotwired/stimulus/pull/520 I realised that `this.identifier` is not documented from what I can see.
* This adds a note about `this.identifier` being available on the Controller's instance