### PR TITLE
Improve Stimulus Values type mismatch error messages

### DIFF
--- a/src/core/value_observer.ts
+++ b/src/core/value_observer.ts
@@ -85,14 +85,21 @@ export class ValueObserver implements StringMapObserverDelegate {
 
     if (typeof changedMethod == "function") {
       const descriptor = this.valueDescriptorNameMap[name]
-      const value = descriptor.reader(rawValue)
-      let oldValue = rawOldValue
 
-      if (rawOldValue) {
-        oldValue = descriptor.reader(rawOldValue)
+      try {
+        const value = descriptor.reader(rawValue)
+        let oldValue = rawOldValue
+
+        if (rawOldValue) {
+          oldValue = descriptor.reader(rawOldValue)
+        }
+
+        changedMethod.call(this.receiver, value, oldValue)
+      } catch (error) {
+        if (!(error instanceof TypeError)) throw error
+
+        throw new TypeError(`Stimulus Value "${this.context.identifier}.${descriptor.name}" - ${error.message}`)
       }
-
-      changedMethod.call(this.receiver, value, oldValue)
     }
   }
 

--- a/src/core/value_properties.ts
+++ b/src/core/value_properties.ts
@@ -119,7 +119,7 @@ function parseValueTypeObject(payload: { controller?: string, token: string, typ
   if (typeFromObject !== defaultValueType) {
     const propertyPath = payload.controller ? `${payload.controller}.${payload.token}` : payload.token
 
-    throw new Error(`Type "${typeFromObject}" for "${propertyPath}" value, must match the type of the default value. Given default value: "${payload.typeObject.default}" as "${defaultValueType}"`)
+    throw new Error(`The specified default value for the Stimulus Value "${propertyPath}" must match the defined type "${typeFromObject}". The provided default value of "${payload.typeObject.default}" is of type "${defaultValueType}".`)
   }
 
   return typeFromObject

--- a/src/core/value_properties.ts
+++ b/src/core/value_properties.ts
@@ -105,29 +105,29 @@ function parseValueTypeDefault(defaultValue: ValueTypeDefault) {
   if (Object.prototype.toString.call(defaultValue) === "[object Object]") return "object"
 }
 
-function parseValueTypeObject(typeObject: ValueTypeObject) {
+function parseValueTypeObject(token: string, typeObject: ValueTypeObject) {
   const typeFromObject = parseValueTypeConstant(typeObject.type)
 
   if (typeFromObject) {
     const defaultValueType = parseValueTypeDefault(typeObject.default)
 
     if (typeFromObject !== defaultValueType) {
-      throw new Error(`Type "${typeFromObject}" must match the type of the default value. Given default value: "${typeObject.default}" as "${defaultValueType}"`)
+      throw new Error(`Type "${typeFromObject}" for "${token}" property, must match the type of the default value. Given default value: "${typeObject.default}" as "${defaultValueType}"`)
     }
 
     return typeFromObject
   }
 }
 
-function parseValueTypeDefinition(typeDefinition: ValueTypeDefinition): ValueType {
-  const typeFromObject = parseValueTypeObject(typeDefinition as ValueTypeObject)
+function parseValueTypeDefinition(token: string, typeDefinition: ValueTypeDefinition): ValueType {
+  const typeFromObject = parseValueTypeObject(token, typeDefinition as ValueTypeObject)
   const typeFromDefaultValue = parseValueTypeDefault(typeDefinition as ValueTypeDefault)
   const typeFromConstant = parseValueTypeConstant(typeDefinition as ValueTypeConstant)
 
   const type = typeFromObject || typeFromDefaultValue || typeFromConstant
   if (type) return type
 
-  throw new Error(`Unknown value type "${typeDefinition}"`)
+  throw new Error(`Unknown value type "${typeDefinition}" for "${token}" property`)
 }
 
 function defaultValueForDefinition(typeDefinition: ValueTypeDefinition): ValueTypeDefault {
@@ -143,7 +143,7 @@ function defaultValueForDefinition(typeDefinition: ValueTypeDefinition): ValueTy
 
 function valueDescriptorForTokenAndTypeDefinition(token: string, typeDefinition: ValueTypeDefinition) {
   const key = `${dasherize(token)}-value`
-  const type = parseValueTypeDefinition(typeDefinition)
+  const type = parseValueTypeDefinition(token, typeDefinition)
   return {
     type,
     key,

--- a/src/core/value_properties.ts
+++ b/src/core/value_properties.ts
@@ -182,7 +182,7 @@ const readers: { [type: string]: Reader } = {
   array(value: string): any[] {
     const array = JSON.parse(value)
     if (!Array.isArray(array)) {
-      throw new TypeError("Expected array")
+      throw new TypeError(`expected value of type "array" but instead got value "${value}" of type "${parseValueTypeDefault(array)}"`)
     }
     return array
   },
@@ -198,7 +198,7 @@ const readers: { [type: string]: Reader } = {
   object(value: string): object {
     const object = JSON.parse(value)
     if (object === null || typeof object != "object" || Array.isArray(object)) {
-      throw new TypeError("Expected object")
+      throw new TypeError(`expected value of type "object" but instead got value "${value}" of type "${parseValueTypeDefault(object)}"`)
     }
     return object
   },

--- a/src/core/value_properties.ts
+++ b/src/core/value_properties.ts
@@ -112,7 +112,7 @@ function parseValueTypeObject(token: string, typeObject: ValueTypeObject) {
     const defaultValueType = parseValueTypeDefault(typeObject.default)
 
     if (typeFromObject !== defaultValueType) {
-      throw new Error(`Type "${typeFromObject}" for "${token}" property, must match the type of the default value. Given default value: "${typeObject.default}" as "${defaultValueType}"`)
+      throw new Error(`Type "${typeFromObject}" for "${token}" value, must match the type of the default value. Given default value: "${typeObject.default}" as "${defaultValueType}"`)
     }
 
     return typeFromObject
@@ -127,7 +127,7 @@ function parseValueTypeDefinition(token: string, typeDefinition: ValueTypeDefini
   const type = typeFromObject || typeFromDefaultValue || typeFromConstant
   if (type) return type
 
-  throw new Error(`Unknown value type "${typeDefinition}" for "${token}" property`)
+  throw new Error(`Unknown value type "${typeDefinition}" for "${token}" value`)
 }
 
 function defaultValueForDefinition(typeDefinition: ValueTypeDefinition): ValueTypeDefault {

--- a/src/core/value_properties.ts
+++ b/src/core/value_properties.ts
@@ -140,10 +140,6 @@ function parseValueTypeDefinition(payload: { controller?: string, token: string,
 
   const propertyPath = payload.controller ? `${payload.controller}.${payload.typeDefinition}` : payload.token
 
-  if (payload.controller) {
-    throw new Error(`Unknown value type "${propertyPath}" for "${payload.token}" value`)
-  }
-
   throw new Error(`Unknown value type "${propertyPath}" for "${payload.token}" value`)
 }
 


### PR DESCRIPTION
The current implementation isn't friendly for debugging, especially when you have multiple controllers on the same page. If your value doesn't match to the expected type you will see a `Uncaught Error: Type "string" must match the type of the default value. Given default value: "undefined" as "undefined"` message.

This PR changes the message and pass value's name into it. Result will look like `The specified default value for the Stimulus Value "property_name" must match the defined type "string". The provided default value of "123" is of type "number".` and so on.