### PR TITLE
Allow refining the type of Controller elements

### DIFF
--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -6,7 +6,7 @@ import { ValuePropertiesBlessing, ValueDefinitionMap } from "./value_properties"
 
 export type ControllerConstructor = Constructor<Controller>
 
-export class Controller {
+export class Controller<ElementType extends Element = Element> {
   static blessings = [ ClassPropertiesBlessing, TargetPropertiesBlessing, ValuePropertiesBlessing ]
   static targets: string[] = []
   static values: ValueDefinitionMap = {}
@@ -30,7 +30,7 @@ export class Controller {
   }
 
   get element() {
-    return this.scope.element
+    return this.scope.element as ElementType
   }
 
   get identifier() {


### PR DESCRIPTION
Use generics to avoid having to repeat type assertions.

This can be used as is:
```ts
class MyFormController extends Controller<HTMLFormElement> {
    submit() {
        new FormData(this.element)
    }
}
```

The default value for that generics means you can still write `class MyController extends Controller {}`.

---

This was inspired by [this conversation](https://discuss.hotwired.dev/t/stimulus-and-typescript/2458/3).