### PR TITLE
log_controller_test_case: Fix deepEqual returning true for primitive types

### DIFF
--- a/src/tests/cases/log_controller_test_case.ts
+++ b/src/tests/cases/log_controller_test_case.ts
@@ -37,7 +37,7 @@ function slice(object: any, keys: string[]): any {
 function deepEqual(obj1: any, obj2: any): boolean {
   if (obj1 === obj2) {
     return true
-  } else {
+  } else if (typeof obj1 === "object" && typeof obj2 === "object") {
     if (Object.keys(obj1).length !== Object.keys(obj2).length) { return false }
     for (var prop in obj1) {
       if (!deepEqual(obj1[prop], obj2[prop])) {
@@ -45,5 +45,7 @@ function deepEqual(obj1: any, obj2: any): boolean {
       }
     }
     return true
+  } else {
+    return false
   }
 }


### PR DESCRIPTION
This PR fixes ``deepEqual`` to return the correct value when comparing primitive types.

When comparing ``obj1`` and ``obj2``, ``deepEqual`` first performs a standard ``===`` check. If that fails, it then proceeds to do a "deep comparison" with each targets' properties. However, since ``Object.keys(obj)`` always returns an empty array for primitive types, this means that ``deepEqual`` will always return ``true`` when comparing primitives as there are no properties to compare. (For example, ``deepEqual(true, false)`` will result in ``true``.)

To avoid this, we only perform the deep comparison if both targets are of type ``object``. If they are not, we return ``false``.

Fixes #532.