### PR TITLE
Remove obsolete document.execCommand

### DIFF
--- a/examples/controllers/clipboard_controller.js
+++ b/examples/controllers/clipboard_controller.js
@@ -11,7 +11,6 @@ export default class extends Controller {
   }
 
   copy() {
-    this.sourceTarget.select()
-    document.execCommand("copy")
+    navigator.clipboard.writeText(this.sourceTarget)
   }
 }


### PR DESCRIPTION
document.execCommand("copy") is obsolete. Although it may still work in some browsers, its use is discouraged since it could be removed at any time.