### PR TITLE
Adds new Action Options, namely `:self` and `:!self`

### DIFF
--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -107,6 +107,8 @@ Custom action option | Description
 -------------------- | -----------
 `:stop`              | calls `.stopPropagation()` on the event before invoking the method
 `:prevent`           | calls `.preventDefault()` on the event before invoking the method
+`:self`              | only invokes the method if the event was fired by the element itself
+`:!self`             | only invokes the method if the event was fired by any of its descendants but not by the element
 
 ## Event Objects
 

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -108,7 +108,6 @@ Custom action option | Description
 `:stop`              | calls `.stopPropagation()` on the event before invoking the method
 `:prevent`           | calls `.preventDefault()` on the event before invoking the method
 `:self`              | only invokes the method if the event was fired by the element itself
-`:!self`             | only invokes the method if the event was fired by any of its descendants but not by the element
 
 ## Event Objects
 

--- a/src/core/binding.ts
+++ b/src/core/binding.ts
@@ -31,7 +31,7 @@ export class Binding {
   }
 
   handleEvent(event: Event) {
-    if (this.willBeInvokedByEvent(event)) {
+    if (this.willBeInvokedByEvent(event) && this.shouldBeInvokedPerSelf(event)) {
       this.processStopPropagation(event);
       this.processPreventDefault(event);
 
@@ -77,19 +77,25 @@ export class Binding {
     }
   }
 
+  private shouldBeInvokedPerSelf(event: Event): boolean {
+    if (this.action.eventOptions.self === true) {
+      return this.action.element === event.target
+    } else if (this.action.eventOptions.self === false) {
+      return this.action.element !== event.target
+    } else {
+      return true
+    }
+  }
+
   private willBeInvokedByEvent(event: Event): boolean {
     const eventTarget = event.target
-
-    let isWithinScopeForExecution;
     if (this.element === eventTarget) {
-      isWithinScopeForExecution = true
+      return true
     } else if (eventTarget instanceof Element && this.element.contains(eventTarget)) {
-      isWithinScopeForExecution = this.scope.containsElement(eventTarget)
+      return this.scope.containsElement(eventTarget)
     } else {
-      isWithinScopeForExecution = this.scope.containsElement(this.action.element)
+      return this.scope.containsElement(this.action.element)
     }
-
-    return isWithinScopeForExecution && (this.action.eventOptions.self === false ? false : true)
   }
 
   private get controller(): Controller {

--- a/src/core/binding.ts
+++ b/src/core/binding.ts
@@ -80,8 +80,6 @@ export class Binding {
   private shouldBeInvokedPerSelf(event: Event): boolean {
     if (this.action.eventOptions.self === true) {
       return this.action.element === event.target
-    } else if (this.action.eventOptions.self === false) {
-      return this.action.element !== event.target
     } else {
       return true
     }

--- a/src/core/binding.ts
+++ b/src/core/binding.ts
@@ -79,13 +79,17 @@ export class Binding {
 
   private willBeInvokedByEvent(event: Event): boolean {
     const eventTarget = event.target
+
+    let isWithinScopeForExecution;
     if (this.element === eventTarget) {
-      return true
+      isWithinScopeForExecution = true
     } else if (eventTarget instanceof Element && this.element.contains(eventTarget)) {
-      return this.scope.containsElement(eventTarget)
+      isWithinScopeForExecution = this.scope.containsElement(eventTarget)
     } else {
-      return this.scope.containsElement(this.action.element)
+      isWithinScopeForExecution = this.scope.containsElement(this.action.element)
     }
+
+    return isWithinScopeForExecution && (this.action.eventOptions.self === false ? false : true)
   }
 
   private get controller(): Controller {

--- a/src/core/event_modifiers.ts
+++ b/src/core/event_modifiers.ts
@@ -1,4 +1,5 @@
 export interface EventModifiers extends AddEventListenerOptions {
   stop?: boolean;
   prevent?: boolean;
+  self?: boolean;
 }

--- a/src/tests/modules/core/event_options_tests.ts
+++ b/src/tests/modules/core/event_options_tests.ts
@@ -190,7 +190,7 @@ export default class EventOptionsTests extends LogControllerTestCase {
     )
   }
 
-  async "test self option true"() {
+  async "test self option"() {
     this.setAction(this.buttonElement, "click->c#log:self")
     await this.nextFrame
 
@@ -201,33 +201,13 @@ export default class EventOptionsTests extends LogControllerTestCase {
     )
   }
 
-  async "test self option false"() {
-    this.setAction(this.buttonElement, "click->c#log:!self")
-    await this.nextFrame
-
-    await this.triggerEvent(this.buttonElement, "click")
-
-    this.assertNoActions()
-  }
-
-  async "test self option true on parent"() {
+  async "test self option on parent"() {
     this.setAction(this.element, "click->c#log:self")
     await this.nextFrame
 
     await this.triggerEvent(this.buttonElement, "click")
 
     this.assertNoActions()
-  }
-
-  async "test self option false on parent"() {
-    this.setAction(this.element, "click->c#log:!self")
-    await this.nextFrame
-
-    await this.triggerEvent(this.buttonElement, "click")
-
-    this.assertActions(
-      { name: "log", eventType: "click" }
-    )
   }
 
   setAction(element: Element, value: string) {

--- a/src/tests/modules/core/event_options_tests.ts
+++ b/src/tests/modules/core/event_options_tests.ts
@@ -221,6 +221,37 @@ export default class EventOptionsTests extends LogControllerTestCase {
     this.assertNoActions()
   }
 
+  async "test self option absence on parent"() {
+    this.setAction(this.element, "click->c#log")
+    await this.nextFrame
+
+    await this.triggerEvent(this.buttonElement, "click")
+
+    this.assertActions(
+      { name: "log", eventType: "click" }
+    )
+  }
+
+  async "test self option true on parent"() {
+    this.setAction(this.element, "click->c#log:self")
+    await this.nextFrame
+
+    await this.triggerEvent(this.buttonElement, "click")
+
+    this.assertNoActions()
+  }
+
+  async "test self option false on parent"() {
+    this.setAction(this.element, "click->c#log:!self")
+    await this.nextFrame
+
+    await this.triggerEvent(this.buttonElement, "click")
+
+    this.assertActions(
+      { name: "log", eventType: "click" }
+    )
+  }
+
   setAction(element: Element, value: string) {
     element.setAttribute("data-action", value)
   }

--- a/src/tests/modules/core/event_options_tests.ts
+++ b/src/tests/modules/core/event_options_tests.ts
@@ -190,6 +190,17 @@ export default class EventOptionsTests extends LogControllerTestCase {
     )
   }
 
+  async "test self option absence"() {
+    this.setAction(this.buttonElement, "click->c#log")
+    await this.nextFrame
+
+    await this.triggerEvent(this.buttonElement, "click")
+
+    this.assertActions(
+      { name: "log", eventType: "click" }
+    )
+  }
+
   setAction(element: Element, value: string) {
     element.setAttribute("data-action", value)
   }

--- a/src/tests/modules/core/event_options_tests.ts
+++ b/src/tests/modules/core/event_options_tests.ts
@@ -190,17 +190,6 @@ export default class EventOptionsTests extends LogControllerTestCase {
     )
   }
 
-  async "test self option absence"() {
-    this.setAction(this.buttonElement, "click->c#log")
-    await this.nextFrame
-
-    await this.triggerEvent(this.buttonElement, "click")
-
-    this.assertActions(
-      { name: "log", eventType: "click" }
-    )
-  }
-
   async "test self option true"() {
     this.setAction(this.buttonElement, "click->c#log:self")
     await this.nextFrame
@@ -219,17 +208,6 @@ export default class EventOptionsTests extends LogControllerTestCase {
     await this.triggerEvent(this.buttonElement, "click")
 
     this.assertNoActions()
-  }
-
-  async "test self option absence on parent"() {
-    this.setAction(this.element, "click->c#log")
-    await this.nextFrame
-
-    await this.triggerEvent(this.buttonElement, "click")
-
-    this.assertActions(
-      { name: "log", eventType: "click" }
-    )
   }
 
   async "test self option true on parent"() {

--- a/src/tests/modules/core/event_options_tests.ts
+++ b/src/tests/modules/core/event_options_tests.ts
@@ -201,7 +201,7 @@ export default class EventOptionsTests extends LogControllerTestCase {
     )
   }
 
-  async "test self option presence"() {
+  async "test self option true"() {
     this.setAction(this.buttonElement, "click->c#log:self")
     await this.nextFrame
 
@@ -212,7 +212,7 @@ export default class EventOptionsTests extends LogControllerTestCase {
     )
   }
 
-  async "test not-self option presence"() {
+  async "test self option false"() {
     this.setAction(this.buttonElement, "click->c#log:!self")
     await this.nextFrame
 

--- a/src/tests/modules/core/event_options_tests.ts
+++ b/src/tests/modules/core/event_options_tests.ts
@@ -201,6 +201,26 @@ export default class EventOptionsTests extends LogControllerTestCase {
     )
   }
 
+  async "test self option presence"() {
+    this.setAction(this.buttonElement, "click->c#log:self")
+    await this.nextFrame
+
+    await this.triggerEvent(this.buttonElement, "click")
+
+    this.assertActions(
+      { name: "log", eventType: "click" }
+    )
+  }
+
+  async "test not-self option presence"() {
+    this.setAction(this.buttonElement, "click->c#log:!self")
+    await this.nextFrame
+
+    await this.triggerEvent(this.buttonElement, "click")
+
+    this.assertNoActions()
+  }
+
   setAction(element: Element, value: string) {
     element.setAttribute("data-action", value)
   }


### PR DESCRIPTION
This PR adds two new Action Options, namely `:self` and `:!self`, as discussed in #530. For more context, please refer to the original issue.

Feel free to provide any suggestions and I'll make sure to accommodate them.