### PR TITLE
Handbook: use clipboard api feature test rather than permission test

### DIFF
--- a/docs/handbook/04_designing_for_resilience.md
+++ b/docs/handbook/04_designing_for_resilience.md
@@ -51,15 +51,13 @@ First we'll add the `data-clipboard-supported-class` attribute inside the contro
 
 This will let us control the specific CSS class in the HTML, so our controller becomes even more easily adaptable to different CSS approaches. The specific class added like this can be accessed via `this.supportedClass`.
 
-Now add a `connect()` method to the controller which will add a class name to the controller's element when the user agent has permission to write to the clipboard:
+Now add a `connect()` method to the controller which will test to see if the clipboard API is supported and add a class name to the controller's element:
 
 ```js
   connect() {
-    navigator.permissions.query({ name: "clipboard-write" }).then((result) => {
-      if (result.state === "granted") {
-        this.element.classList.add(this.supportedClass);
-      }
-    });
+    if ("clipboard" in navigator) {
+      this.element.classList.add(this.supportedClass);
+    }
   }
 ```
 


### PR DESCRIPTION
This code from https://stimulus.hotwired.dev/handbook/designing-for-resilience doesn't work on firefox or safari 

```
  connect() {
    navigator.permissions.query({ name: "clipboard-write" }).then((result) => {
      if (result.state === "granted") {
        this.element.classList.add(this.supportedClass);
      }
    });
  }
```
https://caniuse.com/mdn-api_permissions_clipboard-write_permission

This PR makes it use a API test instead.