### PR TITLE
Fix `exports` field for `stimulus` package and Webpack 5

### DIFF
--- a/packages/stimulus/package.json
+++ b/packages/stimulus/package.json
@@ -13,6 +13,14 @@
   "main": "./dist/stimulus.umd.js",
   "types": "./index.d.ts",
   "exports": {
+    ".": {
+      "main": "./dist/stimulus.umd.js",
+      "browser": "./dist/stimulus.js",
+      "import": "./dist/stimulus.js",
+      "module": "./dist/stimulus.js",
+      "umd": "./dist/stimulus.umd.js",
+      "types": "./index.d.ts"
+    },
     "./webpack-helpers": {
       "main": "./dist/webpack-helpers.umd.js",
       "browser": "./dist/webpack-helpers.js",


### PR DESCRIPTION
without "." defined as export, webpack 5 won't find the requested module (didn't check with other webpack versions).
this happens because the exports field replaces the root-level "module", "main", "types", etc:

> When the exports field is specified, only these module requests are available. Any other requests will lead to a ModuleNotFound Error.

see https://webpack.js.org/guides/package-exports/

this fixes the following error for me:

```
ERROR in ./app/javascript/packs/application.js 2:0-33
Module not found: Error: Package path . is not exported from package ./node_modules/stimulus (see exports field in ./node_modules/stimulus/package.json)
```

also, 3.0.1 does not exibit the issue. i guess this issue was introduced with #468.