### PR TITLE
Retain backtrace for TypeErrors in value change callback

### DIFF
--- a/src/core/value_observer.ts
+++ b/src/core/value_observer.ts
@@ -96,9 +96,11 @@ export class ValueObserver implements StringMapObserverDelegate {
 
         changedMethod.call(this.receiver, value, oldValue)
       } catch (error) {
-        if (!(error instanceof TypeError)) throw error
+        if (error instanceof TypeError) {
+          error.message = `Stimulus Value "${this.context.identifier}.${descriptor.name}" - ${error.message}`
+        }
 
-        throw new TypeError(`Stimulus Value "${this.context.identifier}.${descriptor.name}" - ${error.message}`)
+        throw error
       }
     }
   }


### PR DESCRIPTION
This code was originally added to provide better error messaging for TypeErrors when assigning values.

Unfortunately throwing a new error object causes us to lose the context (including stacktrace) of the original error, making it harder to locate the source.

Changing the message and rethrowing the original error retain that information.

## Before

<img width="876" alt="Screenshot 2022-09-11 at 22 01 34" src="https://user-images.githubusercontent.com/109225/189595702-f64333e2-aefe-4516-8249-509a9f7c2df3.png">

## After

<img width="897" alt="Screenshot 2022-09-11 at 22 11 27" src="https://user-images.githubusercontent.com/109225/189595735-541e8531-0f94-4972-9dae-a79009def5a7.png">

Thanks to @marcoroth for help discussing this issue.