### PR TITLE
Clear dangling EventListeners and Detached Nodes when a controller is removed from the DOM

### DIFF
--- a/src/core/binding_observer.ts
+++ b/src/core/binding_observer.ts
@@ -7,7 +7,7 @@ import { Token, ValueListObserver, ValueListObserverDelegate } from "../mutation
 
 export interface BindingObserverDelegate extends ErrorHandler {
   bindingConnected(binding: Binding): void
-  bindingDisconnected(binding: Binding): void
+  bindingDisconnected(binding: Binding, clearEventListeners?: boolean): void
 }
 
 export class BindingObserver implements ValueListObserverDelegate<Action> {
@@ -72,7 +72,7 @@ export class BindingObserver implements ValueListObserverDelegate<Action> {
   }
 
   private disconnectAllActions() {
-    this.bindings.forEach((binding) => this.delegate.bindingDisconnected(binding))
+    this.bindings.forEach((binding) => this.delegate.bindingDisconnected(binding, true))
     this.bindingsByAction.clear()
   }
 

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -41,14 +41,32 @@ export class Dispatcher implements BindingObserverDelegate {
     this.fetchEventListenerForBinding(binding).bindingConnected(binding)
   }
 
-  bindingDisconnected(binding: Binding) {
+  bindingDisconnected(binding: Binding, clearEventListeners: boolean = false) {
     this.fetchEventListenerForBinding(binding).bindingDisconnected(binding)
+    if (clearEventListeners) this.clearEventListenersForBinding(binding)
   }
 
   // Error handling
 
   handleError(error: Error, message: string, detail: object = {}) {
     this.application.handleError(error, `Error ${message}`, detail)
+  }
+
+  private clearEventListenersForBinding(binding: Binding) {
+    const eventListener = this.fetchEventListenerForBinding(binding)
+    if (!eventListener.hasBindings()) {
+      eventListener.disconnect()
+      this.removeMappedEventListenerFor(binding)
+    }
+  }
+
+  private removeMappedEventListenerFor(binding: Binding) {
+    const { eventTarget, eventName, eventOptions } = binding
+    const eventListenerMap = this.fetchEventListenerMapForEventTarget(eventTarget)
+    const cacheKey = this.cacheKey(eventName, eventOptions)
+
+    eventListenerMap.delete(cacheKey)
+    if (eventListenerMap.size == 0) this.eventListenerMaps.delete(eventTarget)
   }
 
   private fetchEventListenerForBinding(binding: Binding): EventListener {

--- a/src/core/event_listener.ts
+++ b/src/core/event_listener.ts
@@ -43,6 +43,10 @@ export class EventListener implements EventListenerObject {
     }
   }
 
+  hasBindings() {
+    return this.unorderedBindings.size > 0
+  }
+
   get bindings(): Binding[] {
     return Array.from(this.unorderedBindings).sort((left, right) => {
       const leftIndex = left.index,

--- a/src/tests/modules/core/memory_tests.ts
+++ b/src/tests/modules/core/memory_tests.ts
@@ -1,0 +1,22 @@
+import { ControllerTestCase } from "../../cases/controller_test_case"
+
+export default class MemoryTests extends ControllerTestCase() {
+  controllerElement!: Element
+
+  async setup() {
+    this.controllerElement = this.controller.element
+  }
+
+  fixtureHTML = `
+    <div data-controller="${this.identifier}">
+      <button data-action="${this.identifier}#doLog">Log</button>
+      <button data-action="${this.identifier}#doAlert">Alert</button>
+    </div>
+  `
+
+  async "test removing a controller clears dangling eventListeners"() {
+    this.assert.equal(this.application.dispatcher.eventListeners.length, 2)
+    await this.fixtureElement.removeChild(this.controllerElement)
+    this.assert.equal(this.application.dispatcher.eventListeners.length, 0)
+  }
+}


### PR DESCRIPTION
`eventListenerMaps` maps HTML elements handled by Stimulus to `eventListenerMap`, a map of Stimulus EventListeners in this way: `{ HTMLelement: { eventName: EventListener } }`. When a controller HTML is removed from the DOM the dangling EventListeners aren't removed, moreover, the removed HTML elements are still referenced via the `eventListenerMaps` keys. This leads to having multiple detached HTMLelements and eventListeners which can't be GCed hence a memory leak. The leak is fixed by removing the dangling eventListeners and clearing unused `eventListenerMaps` keys. When the HTMLelement is attached again to the DOM, the `eventListenerMaps` and the related `eventListeners` are automatically re-created by Stimulus via the MutationObservers, no data is lost by doing this.

Below is an example to reproduce the issue:

```html
<html>
  <head>
    <title>EventListenerMaps memory leak</title>
    <script type="module">
      import { Application, Controller } from "https://unpkg.com/@hotwired/stimulus/dist/stimulus.js"
      window.Stimulus = Application.start()
      Stimulus.register("boosts", class extends Controller {
        doClick() { process(500) }
      })
    </script>
    <script>
      function process(count) {
        let i = 0
        let handler = setInterval(function(){
          if (++i > count) {
            clearInterval(handler)
          } else {
            document.body.replaceWith(document.body.cloneNode(true))
          }
        }, 1)
      }
    </script>
</head>
<body>
  <div data-controller="boosts">
    To reproduce:
    <ul>
      <li>Check heap snapshot</li>
      <li>Click "trigger leak" button</li>
      <li>Check heap snapshot again</li>
    </ul>
    <button data-action="click->boosts#doClick">trigger leak</button>
  </div>
</body>
</html>
```

heap snapshot before:

<img width="1247" alt="Screenshot 2022-10-19 at 17 10 35" src="https://user-images.githubusercontent.com/1753245/196731392-7991f4ec-cfc4-4e1d-abba-a26c1673875a.png">

heap snapshot after:

<img width="1244" alt="Screenshot 2022-10-19 at 17 11 10" src="https://user-images.githubusercontent.com/1753245/196731443-97445965-f562-48ca-8ddd-5a08bb587ee9.png">

**Related** https://github.com/hotwired/stimulus/issues/489 https://github.com/hotwired/stimulus/issues/547
