### PR TITLE
Ensure that the Application.start static method uses overridden class

### DIFF
--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -17,7 +17,7 @@ export class Application implements ErrorHandler {
   debug = false
 
   static start(element?: Element, schema?: Schema): Application {
-    const application = new Application(element, schema)
+    const application = new this(element, schema)
     application.start()
     return application
   }

--- a/src/tests/modules/core/extending_application_tests.ts
+++ b/src/tests/modules/core/extending_application_tests.ts
@@ -1,0 +1,51 @@
+import { Application } from "../../../core/application"
+import { DOMTestCase } from "../../cases/dom_test_case"
+import { ActionDescriptorFilter } from "src/core/action_descriptor"
+
+const mockCallback: { (label: string): void; lastCall: string | null } = (label: string) => {
+  mockCallback.lastCall = label
+}
+mockCallback.lastCall = null
+
+class TestApplicationWithCustomBehavior extends Application {
+  registerActionOption(name: string, filter: ActionDescriptorFilter): void {
+    mockCallback(`registerActionOption:${name}`)
+    super.registerActionOption(name, filter)
+  }
+}
+
+export default class ExtendingApplicationTests extends DOMTestCase {
+  application!: Application
+
+  async runTest(testName: string) {
+    try {
+      // use the documented way to start & reference only the returned application instance
+      this.application = TestApplicationWithCustomBehavior.start(this.fixtureElement)
+      await super.runTest(testName)
+    } finally {
+      this.application.stop()
+    }
+  }
+
+  async setup() {
+    mockCallback.lastCall = null
+  }
+
+  async teardown() {
+    mockCallback.lastCall = null
+  }
+
+  async "test extended class method is supported when using MyApplication.start()"() {
+    this.assert.equal(mockCallback.lastCall, null)
+
+    const mockTrue = () => true
+    this.application.registerActionOption("kbd", mockTrue)
+    this.assert.equal(this.application.actionDescriptorFilters["kbd"], mockTrue)
+    this.assert.equal(mockCallback.lastCall, "registerActionOption:kbd")
+
+    const mockFalse = () => false
+    this.application.registerActionOption("xyz", mockFalse)
+    this.assert.equal(this.application.actionDescriptorFilters["xyz"], mockFalse)
+    this.assert.equal(mockCallback.lastCall, "registerActionOption:xyz")
+  }
+}


### PR DESCRIPTION
- When using `const application = MyApplication.start()` - it now will use the actual `MyApplication` class instead of the non-extended `Application` class
- Fixes #586

## Notes

I opted for no documentation here - I think this behaviour would be expected and also aligns with any manual `start` usage with instantiation of the class yourself.

For example, the following two ways of starting the application will now be the same (with this PR merged).

### A - Starting an application as per documentation

```javascript
class MyApplication extends Application {}

const element = document.getElementById('main');
const application = MyApplication.start(element); // without this PR - the `application` will be an instance of the Stimulus `Application` and not `MyApplication`
```

### B - Setting up the instance manually & running `start`

```javascript
class MyApplication extends Application {}

const element = document.getElementById('main');
const application = new MyApplication(element);
application.start();
```

## Test format

Note that I had to write my own test case class as `src/tests/cases/application_test_case.ts` does not use the documented `Application.start()` approach (due to other tests relying on a separate setup step for the application before starting).

This is similar to the way that the test file `src/tests/modules/core/error_handler_tests.ts` also sets up its own test case but without the double-registration of a Stimulus application. Happy to adjust if this is not the way we want to do this.
