### PR TITLE
convert examples from Turbolinks to Turbo

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,5 @@
 import { Application } from "@hotwired/stimulus"
-import Turbolinks from "turbolinks"
-
-Turbolinks.start()
+import "@hotwired/turbo"
 
 const application = Application.start()
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -7,10 +7,10 @@
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/plugin-transform-runtime": "^7.14.5",
     "@babel/preset-env": "^7.5.5",
+    "@hotwired/turbo": "^7.2.4",
     "babel-loader": "^8.0.6",
     "ejs": "^3.1.7",
     "express": "^4.16.3",
-    "turbolinks": "^5.2.0",
     "webpack": "^4.39.1",
     "webpack-dev-middleware": "^3.7.0"
   },

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -880,6 +880,11 @@
     "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
+"@hotwired/turbo@^7.2.4":
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.2.4.tgz#0d35541be32cfae3b4f78c6ab9138f5b21f28a21"
+  integrity sha512-c3xlOroHp/cCZHDOuLp6uzQYEbvXBUVaal0puXoGJ9M8L/KHwZ3hQozD4dVeSN9msHWLxxtmPT1TlCN7gFhj4w==
+
 "@types/json-schema@^7.0.5":
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
@@ -3812,11 +3817,6 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
-
-turbolinks@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
While working on another small PR I realized that the Stimulus example are still using Turbolinks. 
This PR migrates them to Turbo.