### PR TITLE
Add the ability to disengage a Stimulus Controller during a page visit

### DIFF
--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -71,6 +71,10 @@ export class Application implements ErrorHandler {
     identifiers.forEach((identifier) => this.router.unloadIdentifier(identifier))
   }
 
+  disengage(): boolean {
+    return false
+  }
+
   // Controllers
 
   get controllers(): Controller[] {

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -27,6 +27,10 @@ export class Controller<ElementType extends Element = Element> {
     return
   }
 
+  static get disengage() {
+    return false
+  }
+
   readonly context: Context
 
   constructor(context: Context) {

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -30,9 +30,11 @@ export class Module {
   }
 
   connectContextForScope(scope: Scope) {
-    const context = this.fetchContextForScope(scope)
-    this.connectedContexts.add(context)
-    context.connect()
+    if (!this.disengage) {
+      const context = this.fetchContextForScope(scope)
+      this.connectedContexts.add(context)
+      context.connect()
+    }
   }
 
   disconnectContextForScope(scope: Scope) {
@@ -50,5 +52,9 @@ export class Module {
       this.contextsByScope.set(scope, context)
     }
     return context
+  }
+
+  private get disengage(): boolean {
+    return (this.definition.controllerConstructor as any).disengage || this.application.disengage()
   }
 }


### PR DESCRIPTION
## Goal

When coupled with Turbo cache it is a very common practice to disable Stimulus controllers during the preview page. 
Not doing so usually generate blink effects. I wrote [something](https://dev.to/adrienpoly/animations-with-turbolinks-and-stimulus-4862) back then in the Turbolinks days and it still pretty much applies.
My personal recommendation is to always disable the controllers for preview pages.

Currently, to achieve this, I have in many places similar code 

```js
  initialize() {
    if (!this.isPreview) {
      ...
    }
  }

  get isPreview() {
    return document.documentElement.hasAttribute("data-turbo-preview")
  }
```

This is a problem I have seen this happening with many new Turbo/Stimulus developers and not easy to grasp for new comers.
I think we should make it easy to disable controllers in the preview page.

## Introduce a way to disengage controllers globally or locally 

This PR brings two new way to disengage controllers

**Globally**

`application` has a disengage function and to solve the preview blink effect it should be set like that 

```js
import { Application } from "@hotwired/stimulus"
import "@hotwired/turbo"

const application = Application.start()

application.disengage = function() {
  return document.documentElement.hasAttribute("data-turbo-preview")
}
```

If we go forward with that I think in the Stimulus Rails generator we should add this by default for a new app.

**Locally**

A controller can also be disengaged locally using a static function 

```js 
export default class extends Controller {
  static get disengage() {
    return document.documentElement.hasAttribute("data-turbo-preview")
  }

  ...
}
```

I choose to go with a static function but this comes with a few limitations as we don't have any access to targets values or other controller content. We could make it an instance function but it could create breaking changes fs for some reasons some people have a function named like that in their controller. 
With a static function the risk looks minimal to me.

## Naming 

Initially I went with `shouldConnect` to be in line with `shouldLoad` but I thought `disengage` would be a better choice for the following reasons :

- disengage expresses a temporary action
- there is a clear distinction with shouldLoad (otherwise those 2 settings would be confusing)
- fits well with Turbo

## Going forward

This is opened as a draft as I wanted to first get feedback on the overall API and can then add the appropriate tests and documentation.

Few questions that I have : 
- Do we want to have the `context` available in this function?  If so the implementation would then be a little more complex and at a lower level. For now, the use cases I have seen are more global than local.
- Do we want to be able to call on an already connected controller the `disengage` function to pause all actions? While being a bit different I think we can achieve that by calling disconnect/connect programmatically.