### PR TITLE
Broken Sauce Labs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ We expect all Stimulus contributors to abide by the terms of our [Code of Conduc
 
 Stimulus is [MIT-licensed](LICENSE.md) open-source software from [Basecamp](https://basecamp.com/), the creators of [Ruby on Rails](http://rubyonrails.org).
 
-Continuous integration VMs generously provided by [Sauce Labs](https://saucelabs.com/open-source).
+Continuous integration VMs generously provided by [Sauce Labs](https://opensource.saucelabs.com/).
 
 ---
 


### PR DESCRIPTION
I found Sauce Labs link in README returns 502, so I fix it to correct one.

<img width="1389" alt="スクリーンショット 2022-11-28 15 59 40" src="https://user-images.githubusercontent.com/7752434/204213852-10ed3f0d-011f-4b78-a5f7-023cd4d87195.png">
