### PR TITLE
Enable keyfilter only for keydown, keyup, and keypress.

### DIFF
--- a/src/core/action_descriptor.ts
+++ b/src/core/action_descriptor.ts
@@ -44,13 +44,21 @@ const descriptorPattern = /^(?:(.+?)(?:\.(.+?))?(?:@(window|document))?->)?(.+?)
 export function parseActionDescriptorString(descriptorString: string): Partial<ActionDescriptor> {
   const source = descriptorString.trim()
   const matches = source.match(descriptorPattern) || []
+  let eventName = matches[1];
+  let keyFilter = matches[2];
+
+  if (keyFilter && !['keydown', 'keyup', 'keypress'].includes(eventName)) {
+    eventName += keyFilter;
+    keyFilter = '';
+  }
+
   return {
     eventTarget: parseEventTarget(matches[3]),
-    eventName: matches[1],
+    eventName,
     eventOptions: matches[6] ? parseEventOptions(matches[6]) : {},
     identifier: matches[4],
     methodName: matches[5],
-    keyFilter: matches[2],
+    keyFilter,
   }
 }
 

--- a/src/core/action_descriptor.ts
+++ b/src/core/action_descriptor.ts
@@ -48,7 +48,7 @@ export function parseActionDescriptorString(descriptorString: string): Partial<A
   let keyFilter = matches[2];
 
   if (keyFilter && !['keydown', 'keyup', 'keypress'].includes(eventName)) {
-    eventName += keyFilter;
+    eventName += `.${keyFilter}`;
     keyFilter = '';
   }
 

--- a/src/core/action_descriptor.ts
+++ b/src/core/action_descriptor.ts
@@ -44,12 +44,12 @@ const descriptorPattern = /^(?:(.+?)(?:\.(.+?))?(?:@(window|document))?->)?(.+?)
 export function parseActionDescriptorString(descriptorString: string): Partial<ActionDescriptor> {
   const source = descriptorString.trim()
   const matches = source.match(descriptorPattern) || []
-  let eventName = matches[1];
-  let keyFilter = matches[2];
+  let eventName = matches[1]
+  let keyFilter = matches[2]
 
-  if (keyFilter && !['keydown', 'keyup', 'keypress'].includes(eventName)) {
-    eventName += `.${keyFilter}`;
-    keyFilter = '';
+  if (keyFilter && !["keydown", "keyup", "keypress"].includes(eventName)) {
+    eventName += `.${keyFilter}`
+    keyFilter = ""
   }
 
   return {

--- a/src/tests/modules/core/action_keyboard_filter_tests.ts
+++ b/src/tests/modules/core/action_keyboard_filter_tests.ts
@@ -21,6 +21,7 @@ export default class ActionKeyboardFilterTests extends LogControllerTestCase {
       <button id="button7"></button>
       <button id="button8" data-action="keydown.a->a#log keydown.b->a#log2"></button>
       <button id="button9" data-action="keydown.shift+a->a#log keydown.a->a#log2 keydown.ctrl+shift+a->a#log3">
+      <button id="button10" data-action="jquery.custom.event->a#log jquery.a->a#log2">
     </div>
   `
 
@@ -181,5 +182,19 @@ export default class ActionKeyboardFilterTests extends LogControllerTestCase {
     await this.nextFrame
     await this.triggerKeyboardEvent(button, "keydown", { key: "A", ctrlKey: true, shiftKey: true })
     this.assertActions({ name: "log3", identifier: "a", eventType: "keydown", currentTarget: button })
+  }
+
+  async "test ignore filter syntax when not a keyboard event"() {
+    const button = this.findElement("#button10")
+    await this.nextFrame
+    await this.triggerEvent(button, "jquery.custom.event")
+    this.assertActions({ name: "log", identifier: "a", eventType: "jquery.custom.event", currentTarget: button })
+  }
+
+  async "test ignore filter syntax when not a keyboard event (case2)"() {
+    const button = this.findElement("#button10")
+    await this.nextFrame
+    await this.triggerEvent(button, "jquery.a")
+    this.assertActions({ name: "log2", identifier: "a", eventType: "jquery.a", currentTarget: button })
   }
 }


### PR DESCRIPTION
I would like to ease the conflict between jQuery's event namespace feature and the hotkey syntax.
To do so, I have made keyFilter interpret only keyup, keydown, and (keypress) as syntax.

related: #612, https://github.com/hotwired/stimulus/pull/442#issuecomment-1330223619