### PR TITLE
Fixed error message in outlet_properties

### DIFF
--- a/src/core/outlet_properties.ts
+++ b/src/core/outlet_properties.ts
@@ -24,7 +24,7 @@ function propertiesForOutletDefinition(name: string) {
             return outletController
           } else {
             throw new Error(
-              `Missing "data-controller=${name}" attribute on outlet element for "${this.identifier}" controller`
+              `Missing "${this.application.schema.controllerAttribute}=${name}" attribute on outlet element for "${this.identifier}" controller`
             )
           }
         }


### PR DESCRIPTION
The error message hard-coded `data-controller` instead of referring to the schema's attribute name