### PR TITLE
Support keyboard modifier for click events

### DIFF
--- a/src/core/action_descriptor.ts
+++ b/src/core/action_descriptor.ts
@@ -38,14 +38,14 @@ export interface ActionDescriptor {
   keyFilter: string
 }
 
-// capture nos.:               1   1     2   2      3               3      4   4    5      5     6  6
-const descriptorPattern = /^(?:(.+?)(?:\.(.+?))?(?:@(window|document))?->)?(.+?)(?:#([^:]+?))(?::(.+))?$/
+// capture nos.:                  1      1    2   2     3   3      4               4      5   5    6      6     7  7
+const descriptorPattern = /^(?:(?:([^.]+?)\+)?(.+?)(?:\.(.+?))?(?:@(window|document))?->)?(.+?)(?:#([^:]+?))(?::(.+))?$/
 
 export function parseActionDescriptorString(descriptorString: string): Partial<ActionDescriptor> {
   const source = descriptorString.trim()
   const matches = source.match(descriptorPattern) || []
-  let eventName = matches[1]
-  let keyFilter = matches[2]
+  let eventName = matches[2]
+  let keyFilter = matches[3]
 
   if (keyFilter && !["keydown", "keyup", "keypress"].includes(eventName)) {
     eventName += `.${keyFilter}`
@@ -53,12 +53,12 @@ export function parseActionDescriptorString(descriptorString: string): Partial<A
   }
 
   return {
-    eventTarget: parseEventTarget(matches[3]),
+    eventTarget: parseEventTarget(matches[4]),
     eventName,
-    eventOptions: matches[6] ? parseEventOptions(matches[6]) : {},
-    identifier: matches[4],
-    methodName: matches[5],
-    keyFilter,
+    eventOptions: matches[7] ? parseEventOptions(matches[7]) : {},
+    identifier: matches[5],
+    methodName: matches[6],
+    keyFilter: matches[1] || keyFilter,
   }
 }
 

--- a/src/core/binding.ts
+++ b/src/core/binding.ts
@@ -82,7 +82,11 @@ export class Binding {
   private willBeInvokedByEvent(event: Event): boolean {
     const eventTarget = event.target
 
-    if (event instanceof KeyboardEvent && this.action.isFilterTarget(event)) {
+    if (event instanceof KeyboardEvent && this.action.shouldIgnoreKeyboardEvent(event)) {
+      return false
+    }
+
+    if (event instanceof MouseEvent && this.action.shouldIgnoreMouseEvent(event)) {
       return false
     }
 

--- a/src/tests/cases/dom_test_case.ts
+++ b/src/tests/cases/dom_test_case.ts
@@ -51,6 +51,15 @@ export class DOMTestCase extends TestCase {
     return event
   }
 
+  async triggerMouseEvent(selectorOrTarget: string | EventTarget, type: string, options: MouseEventInit = {}) {
+    const eventTarget = typeof selectorOrTarget == "string" ? this.findElement(selectorOrTarget) : selectorOrTarget
+    const event = new MouseEvent(type, options)
+
+    eventTarget.dispatchEvent(event)
+    await this.nextFrame
+    return event
+  }
+
   async triggerKeyboardEvent(selectorOrTarget: string | EventTarget, type: string, options: KeyboardEventInit = {}) {
     const eventTarget = typeof selectorOrTarget == "string" ? this.findElement(selectorOrTarget) : selectorOrTarget
     const event = new KeyboardEvent(type, options)

--- a/src/tests/modules/core/action_click_filter_tests.ts
+++ b/src/tests/modules/core/action_click_filter_tests.ts
@@ -1,0 +1,21 @@
+import { LogControllerTestCase } from "../../cases/log_controller_test_case"
+
+export default class ActionClickFilterTests extends LogControllerTestCase {
+  identifier = ["a"]
+
+  fixtureHTML = `
+    <div data-controller="a">
+      <button id="ctrl" data-action="click->a#log ctrl+click->a#log2 meta+click->a#log3"></button>
+    </div>
+  `
+
+  async "test ignoring clicks with unmatched modifier"() {
+    const button = this.findElement("#ctrl")
+    await this.triggerMouseEvent(button, "click", { ctrlKey: true })
+    await this.nextFrame
+    this.assertActions(
+      { name: "log", identifier: "a", eventType: "click", currentTarget: button },
+      { name: "log2", identifier: "a", eventType: "click", currentTarget: button }
+    )
+  }
+}


### PR DESCRIPTION
This commit adds functionality to accept modifiers for click events, e.g., `ctrl+click->link#open`.