### PR TITLE
Add naming requirement for outlet controller identifiers to docs

### DIFF
--- a/docs/reference/outlets.md
+++ b/docs/reference/outlets.md
@@ -33,7 +33,7 @@ While a **target** is a specifically marked element **within the scope** of its 
 
 ## Attributes and Names
 
-The `data-search-result-outlet` attribute is called an _outlet attribute_, and its value is a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) which you can use to refer to other controller elements which should be available as outlets on the _host controller_. The outlet identifier in the host controller **must be the same** as the target controller's name.
+The `data-search-result-outlet` attribute is called an _outlet attribute_, and its value is a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) which you can use to refer to other controller elements which should be available as outlets on the _host controller_. The outlet identifier in the host controller must be the same as the target controller's name.
 
 ```html
 data-[identifier]-[outlet]-outlet="[selector]"

--- a/docs/reference/outlets.md
+++ b/docs/reference/outlets.md
@@ -33,7 +33,7 @@ While a **target** is a specifically marked element **within the scope** of its 
 
 ## Attributes and Names
 
-The `data-search-result-outlet` attribute is called an _outlet attribute_, and its value is a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) which you can use to refer to other controller elements which should be available as outlets on the _host controller_.
+The `data-search-result-outlet` attribute is called an _outlet attribute_, and its value is a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) which you can use to refer to other controller elements which should be available as outlets on the _host controller_. The outlet identifier in the host controller **must be the same** as the target controller's name.
 
 ```html
 data-[identifier]-[outlet]-outlet="[selector]"


### PR DESCRIPTION
👋 

Something we ran into when trying to use outlets was not noticing that the identifier used for the outlet must match the registered controller name exactly. This was also brought up in [this issue](https://github.com/hotwired/stimulus/issues/669). The fact that the naming convention for outlets is different to targets is another matter, and one which is being discussed (would be a great improvement).

I realise this seems to be one of many PRs related to improving the outlets documentation, so if it's one too many then feel free to close it, but this one sentence probably would have saved us some time (assuming we read it of course!).