### PR TITLE
Fix: Actions with options may run out of order

### DIFF
--- a/src/core/action_descriptor.ts
+++ b/src/core/action_descriptor.ts
@@ -29,6 +29,13 @@ export const defaultActionDescriptorFilters: ActionDescriptorFilters = {
   },
 }
 
+export const nativeActionDescriptors: string[] = [
+  "capture",
+  "once",
+  "passive",
+  "!passive"
+]
+
 export interface ActionDescriptor {
   eventTarget: EventTarget
   eventOptions: AddEventListenerOptions

--- a/src/core/dispatcher.ts
+++ b/src/core/dispatcher.ts
@@ -2,6 +2,7 @@ import { Application } from "./application"
 import { Binding } from "./binding"
 import { BindingObserverDelegate } from "./binding_observer"
 import { EventListener } from "./event_listener"
+import { nativeActionDescriptors } from "./action_descriptor"
 
 export class Dispatcher implements BindingObserverDelegate {
   readonly application: Application
@@ -112,8 +113,9 @@ export class Dispatcher implements BindingObserverDelegate {
 
   private cacheKey(eventName: string, eventOptions: any): string {
     const parts = [eventName]
-    Object.keys(eventOptions)
-      .sort()
+
+    nativeActionDescriptors
+      .filter((key) => key in eventOptions)
       .forEach((key) => {
         parts.push(`${eventOptions[key] ? "" : "!"}${key}`)
       })

--- a/src/tests/modules/core/action_ordering_tests.ts
+++ b/src/tests/modules/core/action_ordering_tests.ts
@@ -34,6 +34,18 @@ export default class ActionOrderingTests extends LogControllerTestCase {
     )
   }
 
+  async "test adding an action to the left with a :stop modifier"() {
+    this.actionValue = "c#log3:stop c#log d#log2"
+    await this.nextFrame
+    await this.triggerEvent(this.buttonElement, "click")
+
+    this.assertActions(
+      { name: "log3", identifier: "c", eventType: "click", currentTarget: this.buttonElement },
+      { name: "log", identifier: "c", eventType: "click", currentTarget: this.buttonElement },
+      { name: "log2", identifier: "d", eventType: "click", currentTarget: this.buttonElement }
+    )
+  }
+
   async "test removing an action from the right"() {
     this.actionValue = "c#log d#log2"
     await this.nextFrame


### PR DESCRIPTION
## Problem

I was exploring implementing a new action option -`:stopImmediate` - and in working on that, I ran across what I believe is a bug in action ordering when options are provided.

Consider the following, assuming there is a controller called `a`:
```
<input data-action="keydown->a#firstAction:stop">
```
Then let's say I modify the element with JS dynamically to have a second action like this:
```
<input data-action="keydown->a#firstAction:stop keydown->a#secondAction">
```
When I run these actions, I would expect them to run in left-to-right order, as specified in the docs. However, that doesn't happen - the actions run in `secondAction, firstAction` order. Technically, the `stop` actually happens in between the `secondAction` and `firstAction`, since it runs before the action it modifies.

## Cause

A single event handler is attached on an element for each event type + action option(s) combination. This makes sense for options which are passed to the native DOM handlers - we need these to be separate event handlers under the hood, as they are constructed differently.

For both the "standard" Stimulus set (currently `:stop`,`:prevent`, `:self`) and the user-defined option set added via `registerActionOption()`, the underlying event handler could be the same as in actions without these options. 

## Proposed Solution

I modified the `Dispatcher#cacheKey` method to only create separate keys (and therefore, separate event handlers) when using the 4 action options which are passed to the native `addEventListener`. This lets us run more (but, as mentioned below, not _all_) actions in the correct sequence.

### Caveats

This solution does not fix the issue if I replace the `:stop` in my example above with `:once` - any option handled natively by the browser could still run in an unexpected order. I still believe this is valuable because it patches several (most?) usages (and opens the way for a `:stopImmediate` action option that stops further processing as expected, without having to call `event.stopImmediatePropagation()` in the action).

The more general case is much harder to fix. We could maintain a single event listener per event type (ignoring action options), and implement the `:once` ourselves - but that doesn't help with `:passive` (though I suppose it'd be unusual to attach a `:passive` handler alongside something that's not `:passive` for the same event, that would seem to defeat the point). 

Maybe we could track which bindings have already executed for a given event, but that's its own can of worms.

Or, we could move towards a separation of native browser event attributes and Stimulus- or user-implemented actions. Perhaps putting browser-driven modifiers next to the event type itself could help since they apply at a deeper level - ex. `keydown:once->a#firstAction`)

Then, the section after the `->` could support a larger set of options / filters. Something like `keydown:once->beforeOption:a#firstAction:stop`. (I personally find it unintuitive that `a#firstAction:stop` means that `stop` runs _before_ `firstAction`)

Anyway - that's all a much larger discussion that may be out of scope here. I do think this patch is worthwhile for making more of the action + option combos run in the expected order today.