### PR TITLE
Introduce `application.lazyLoadingControllers` config

### DIFF
--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -15,6 +15,7 @@ export class Application implements ErrorHandler {
   readonly actionDescriptorFilters: ActionDescriptorFilters
   logger: Logger = console
   debug = false
+  lazyLoadingControllers = false
 
   static start(element?: Element, schema?: Schema): Application {
     const application = new this(element, schema)

--- a/src/tests/modules/core/application_tests.ts
+++ b/src/tests/modules/core/application_tests.ts
@@ -45,6 +45,16 @@ export default class ApplicationTests extends ApplicationTestCase {
     this.assert.ok(this.controllers[0] instanceof BController)
   }
 
+  "test Application#lazyLoadingControllers"() {
+    this.assert.equal(this.application.lazyLoadingControllers, false)
+
+    this.application.lazyLoadingControllers = true
+    this.assert.equal(this.application.lazyLoadingControllers, true)
+
+    this.application.lazyLoadingControllers = false
+    this.assert.equal(this.application.lazyLoadingControllers, false)
+  }
+
   get controllers() {
     return this.application.controllers as LogController[]
   }


### PR DESCRIPTION
This configuration is used to indicate if the Stimulus application is lazy loading its Stimulus controllers or if the controllers are being eager loaded.

Ideally this configuration wouldn't be necessary in the first place, but since the logic for handling lazy/eager loading Stimulus controllers with Importmaps is handled in [`stimulus-loading.js` in `stimulus-rails`](https://github.com/hotwired/stimulus-rails/blob/498902a3687d32bd6589f7d3c7e7d72eabd822c0/app/assets/javascripts/stimulus-loading.js) we can't really control/check the current setting.

This pull request allows the functions in `stimulus-loading.js` to set `application.lazyLoadingControllers = true` so the actual Stimulus application knows the loading approach. With that we can control behavior like showing "unregistered controller warnings" based on this setting (see #413 and #653).

Since Stimulus is autoloading controllers in the lazy loading mode we can't really know if/when we should show an unregistered controller warning since they are being fetched on-the-fly. Down the road we probably want to integrate the lazy loading approaches directly into `@hotwired/stimulus` itself se we have more control over this behavior.

**Note:** for now `application.lazyLoadingControllers` is considered "private", we don't expect developers to set that config in their applications.
