### PR TITLE
Pass the `Controller` instance to `registerActionOption` callback

### DIFF
--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -215,12 +215,13 @@ route the event to the controller action, return `true`.
 
 The callback accepts a single object argument with the following keys:
 
-| Name    | Description                                                                                           |
-| ------- | ----------------------------------------------------------------------------------------------------- |
-| name    | String: The option's name (`"open"` in the example above)                                             |
-| value   | Boolean: The value of the option (`:open` would yield `true`, `:!open` would yield `false`)           |
-| event   | [Event][]: The event instance, including with the `params` action parameters on the submitter element |
-| element | [Element]: The element where the action descriptor is declared                                        |
+| Name       | Description                                                                                           |
+| ---------- | ----------------------------------------------------------------------------------------------------- |
+| name       | String: The option's name (`"open"` in the example above)                                             |
+| value      | Boolean: The value of the option (`:open` would yield `true`, `:!open` would yield `false`)           |
+| event      | [Event][]: The event instance, including with the `params` action parameters on the submitter element |
+| element    | [Element]: The element where the action descriptor is declared                                        |
+| controller | The `Controller` instance which would receive the method call                                         |
 
 [toggle]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLDetailsElement/toggle_event
 [Event]: https://developer.mozilla.org/en-US/docs/web/api/event

--- a/src/core/action_descriptor.ts
+++ b/src/core/action_descriptor.ts
@@ -1,3 +1,5 @@
+import type { Controller } from "./controller"
+
 export type ActionDescriptorFilters = Record<string, ActionDescriptorFilter>
 export type ActionDescriptorFilter = (options: ActionDescriptorFilterOptions) => boolean
 type ActionDescriptorFilterOptions = {
@@ -5,6 +7,7 @@ type ActionDescriptorFilterOptions = {
   value: boolean
   event: Event
   element: Element
+  controller: Controller<Element>
 }
 
 export const defaultActionDescriptorFilters: ActionDescriptorFilters = {

--- a/src/core/binding.ts
+++ b/src/core/binding.ts
@@ -50,6 +50,7 @@ export class Binding {
   private applyEventModifiers(event: Event): boolean {
     const { element } = this.action
     const { actionDescriptorFilters } = this.context.application
+    const { controller } = this.context
 
     let passes = true
 
@@ -57,7 +58,7 @@ export class Binding {
       if (name in actionDescriptorFilters) {
         const filter = actionDescriptorFilters[name]
 
-        passes = passes && filter({ name, value, event, element })
+        passes = passes && filter({ name, value, event, element, controller })
       } else {
         continue
       }


### PR DESCRIPTION
- Add ability for `registerActionOption` callbacks to receive the controller instance
- Relates to #668