### PR TITLE
Pass the `ActionEvent` (with params) to `registerActionOption` callbacks

### DIFF
--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -131,7 +131,7 @@ The list of supported modifier keys is shown below.
 
 Sometimes a controller needs to listen for events dispatched on the global `window` or `document` objects.
 
-You can append `@window` or `@document` to the event name (along with any filter modifier) in an action descriptor to install the event listener on `window` or `document`, respectively, as in the following example:
+You can append `@window` or `@document` to the event name (along with any filter modifer) in an action descriptor to install the event listener on `window` or `document`, respectively, as in the following example:
 
 <meta data-controller="callout" data-callout-text-value="resize@window">
 
@@ -215,12 +215,12 @@ route the event to the controller action, return `true`.
 
 The callback accepts a single object argument with the following keys:
 
-Name    | Description
---------|------------
-name    | String: The option's name (`"open"` in the example above)
-value   | Boolean: The value of the option (`:open` would yield `true`, `:!open` would yield `false`)
-event   | [Event][]: The event instance
-element | [Element]: The element where the action descriptor is declared
+| Name    | Description                                                                                           |
+| ------- | ----------------------------------------------------------------------------------------------------- |
+| name    | String: The option's name (`"open"` in the example above)                                             |
+| value   | Boolean: The value of the option (`:open` would yield `true`, `:!open` would yield `false`)           |
+| event   | [Event][]: The event instance, including with the `params` action parameters on the submitter element |
+| element | [Element]: The element where the action descriptor is declared                                        |
 
 [toggle]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLDetailsElement/toggle_event
 [Event]: https://developer.mozilla.org/en-US/docs/web/api/event

--- a/src/core/binding.ts
+++ b/src/core/binding.ts
@@ -29,8 +29,9 @@ export class Binding {
   }
 
   handleEvent(event: Event) {
-    if (this.willBeInvokedByEvent(event) && this.applyEventModifiers(event)) {
-      this.invokeWithEvent(event)
+    const actionEvent = this.prepareActionEvent(event)
+    if (this.willBeInvokedByEvent(event) && this.applyEventModifiers(actionEvent)) {
+      this.invokeWithEvent(actionEvent)
     }
   }
 
@@ -65,12 +66,14 @@ export class Binding {
     return passes
   }
 
-  private invokeWithEvent(event: Event) {
+  private prepareActionEvent(event: Event): ActionEvent {
+    return Object.assign(event, { params: this.action.params })
+  }
+
+  private invokeWithEvent(event: ActionEvent) {
     const { target, currentTarget } = event
     try {
-      const { params } = this.action
-      const actionEvent: ActionEvent = Object.assign(event, { params })
-      this.method.call(this.controller, actionEvent)
+      this.method.call(this.controller, event)
       this.context.logDebugActivity(this.methodName, { event, target, currentTarget, action: this.methodName })
     } catch (error: any) {
       const { identifier, controller, element, index } = this


### PR DESCRIPTION
- Add ability for registerActionOption callbacks to receive the event after `params` have been resolved
- Relates to #668