### PR TITLE
Update Values.md documentation

### DIFF
--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -14,7 +14,7 @@ You can read and write [HTML data attributes](https://developer.mozilla.org/en-U
 </div>
 ```
 
-Data attributes used for values must be declared on the controlled element, the same one that has the `data-controller `attribute.
+Data attributes used for values must be declared on the controlled element, the same one that has the `data-controller` attribute.
 
 <meta data-controller="callout" data-callout-text-value="static values = { url: String }">
 <meta data-controller="callout" data-callout-text-value="this.urlValue">

--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -14,7 +14,7 @@ You can read and write [HTML data attributes](https://developer.mozilla.org/en-U
 </div>
 ```
 
-As per the given HTML snippet, remember to place the values for data attributes within the same element alongside the controller data attribute.
+As per the given HTML snippet, remember to place the data attributes for values on the same element as the `data-controller` attribute.
 
 <meta data-controller="callout" data-callout-text-value="static values = { url: String }">
 <meta data-controller="callout" data-callout-text-value="this.urlValue">

--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -14,7 +14,7 @@ You can read and write [HTML data attributes](https://developer.mozilla.org/en-U
 </div>
 ```
 
-The definition of the value data attribute should be specified in the same location as the controller data attribute.
+Data attributes used for values must be declared on the controlled element, the same one that has the `data-controller `attribute.
 
 <meta data-controller="callout" data-callout-text-value="static values = { url: String }">
 <meta data-controller="callout" data-callout-text-value="this.urlValue">

--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -10,10 +10,11 @@ You can read and write [HTML data attributes](https://developer.mozilla.org/en-U
 <meta data-controller="callout" data-callout-text-value="data-loader-url-value=&quot;/messages&quot;">
 
 ```html
-<div data-controller="loader"
-     data-loader-url-value="/messages">
+<div data-controller="loader" data-loader-url-value="/messages">
 </div>
 ```
+
+The definition of the value data attribute should be specified in the same location as the controller data attribute.
 
 <meta data-controller="callout" data-callout-text-value="static values = { url: String }">
 <meta data-controller="callout" data-callout-text-value="this.urlValue">

--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -14,7 +14,7 @@ You can read and write [HTML data attributes](https://developer.mozilla.org/en-U
 </div>
 ```
 
-Data attributes used for values must be declared on the controlled element, the same one that has the `data-controller` attribute.
+As per the given HTML snippet, remember to place the values for data attributes within the same element alongside the controller data attribute.
 
 <meta data-controller="callout" data-callout-text-value="static values = { url: String }">
 <meta data-controller="callout" data-callout-text-value="this.urlValue">


### PR DESCRIPTION
Updates: https://stimulus.hotwired.dev/reference/values

This PR aims to improve clarity for newcomers regarding the usage of the value data attribute. It emphasizes that the value data attribute should be defined in the same location as the controller. This clarification can help prevent unnecessary debugging efforts, as it took me around 15 minutes to resolve this issue personally.