### PR TITLE
Docs: mention that controller references should be kebab-case on manual registration to avoid issues with targets

### DIFF
--- a/docs/reference/controllers.md
+++ b/docs/reference/controllers.md
@@ -138,6 +138,8 @@ import ReferenceController from "./controllers/reference_controller"
 application.register("reference", ReferenceController)
 ```
 
+Use kebab-case in references to ensure features like targets function correctly (i.e., controllers/date_picker_controller, DatePickerController, date-picker)
+
 You can also register a controller class inline instead of importing it from a module:
 
 ```js


### PR DESCRIPTION
add an explizit line that kebab-case should be used when manually registering controller in order to avoid issues further down then line with targets. Technically snake_case also works, but that results in an unpredictable target naming. Especially in combination with the rails helper tag.div ... data: {foo_bar_target: :baz}

https://discord.com/channels/988103760050012160/1044659701213835294/1160906429109125240
