### PR TITLE
Specify stimulus targets must be child components

### DIFF
--- a/docs/handbook/02_hello_stimulus.md
+++ b/docs/handbook/02_hello_stimulus.md
@@ -133,7 +133,7 @@ We'll finish the exercise by changing our action to say hello to whatever name w
 
 In order to do that, first we need a reference to the input element inside our controller. Then we can read the `value` property to get its contents.
 
-Stimulus lets us mark important elements as _targets_ so we can easily reference them in the controller through corresponding properties. Open `public/index.html` and add a `data-hello-target` attribute to the input element:
+Stimulus lets us mark important child elements as _targets_ so we can easily reference them in the controller through corresponding properties. Open `public/index.html` and add a `data-hello-target` attribute to the input element:
 
 ```html
 <div data-controller="hello">

--- a/docs/handbook/03_building_something_real.md
+++ b/docs/handbook/03_building_something_real.md
@@ -145,7 +145,7 @@ Now let's add one more PIN field. This time we'll use a Copy _link_ instead of a
 </div>
 ```
 
-Stimulus lets us use any kind of element we want as long as it has an appropriate `data-action` attribute.
+Stimulus lets us use any kind of element we want as long as it has an appropriate `data-action` attribute, and is a child of the controller component.
 
 Note that in this case, clicking the link will also cause the browser to follow the link's `href`. We can cancel this default behavior by calling `event.preventDefault()` in the action:
 


### PR DESCRIPTION
It isn't clear in the docs that targets must be children of the component that has the data-controller attribute. This pr attempts to fix that.