### PR TITLE
Allow for default method for controller actions

### DIFF
--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -28,7 +28,7 @@ export class Action {
     this.eventName = descriptor.eventName || getDefaultEventNameForElement(element) || error("missing event name")
     this.eventOptions = descriptor.eventOptions || {}
     this.identifier = descriptor.identifier || error("missing identifier")
-    this.methodName = descriptor.methodName || error("missing method name")
+    this.methodName = descriptor.methodName || "_"
     this.keyFilter = descriptor.keyFilter || ""
     this.schema = schema
   }

--- a/src/core/action_descriptor.ts
+++ b/src/core/action_descriptor.ts
@@ -42,7 +42,7 @@ export interface ActionDescriptor {
 }
 
 // capture nos.:                  1      1    2   2     3   3      4               4      5   5    6      6     7  7
-const descriptorPattern = /^(?:(?:([^.]+?)\+)?(.+?)(?:\.(.+?))?(?:@(window|document))?->)?(.+?)(?:#([^:]+?))(?::(.+))?$/
+const descriptorPattern = /^(?:(?:([^.]+?)\+)?(.+?)(?:\.(.+?))?(?:@(window|document))?->)?(.+?)?(?:#([^:]+?))?(?::(.+))?$/
 
 export function parseActionDescriptorString(descriptorString: string): Partial<ActionDescriptor> {
   const source = descriptorString.trim()

--- a/src/tests/controllers/log_controller.ts
+++ b/src/tests/controllers/log_controller.ts
@@ -30,6 +30,10 @@ export class LogController extends Controller {
     this.disconnectCount++
   }
 
+  _(event: ActionEvent) {
+    this.recordAction("default", event)
+  }
+
   log(event: ActionEvent) {
     this.recordAction("log", event)
   }

--- a/src/tests/modules/core/action_tests.ts
+++ b/src/tests/modules/core/action_tests.ts
@@ -5,6 +5,7 @@ export default class ActionTests extends LogControllerTestCase {
   fixtureHTML = `
     <div data-controller="c" data-action="keydown@window->c#log">
       <button data-action="c#log"><span>Log</span></button>
+      <button id="default" data-action="c"><span>Default</span></button>
       <div id="outer" data-action="click->c#log">
         <div id="inner" data-controller="c" data-action="click->c#log keyup@window->c#log"></div>
       </div>
@@ -19,6 +20,11 @@ export default class ActionTests extends LogControllerTestCase {
   async "test default event"() {
     await this.triggerEvent("button", "click")
     this.assertActions({ name: "log", eventType: "click" })
+  }
+
+  async "test default method"() {
+    await this.triggerEvent("#default", "click")
+    this.assertActions({ name: "default", eventType: "click" })
   }
 
   async "test bubbling events"() {


### PR DESCRIPTION
Hi, I raised the possibility of allowing for devs to omit the method on an action and use a default method in issue #754 and put together a PR to see if there is any interest in this.
 
This allows for actions to omit the method and use `_` as the method name on the controller. This will make it simpiler to use single method controllers.

For example if we have a controller that disables an element before we would write something like this:-

```html
  <button data-controller="disable" data-action="click->disable#disable">Disable on click</button>
```

```js
class DisableController extends Controller {
  disable({target}) {
    target.disabled = true
  }
}
```

After we can shorten the `data-action` attribute like this:-

```html
  <button data-controller="disable" data-action="click->disable">Disable on click</button>
```

```js
class DisableController extends Controller {
  _({target}) {
    target.disabled = true
  }
}
```

This makes it easier for developers to write the controller as they can give the controller a clear name and not have to construct a name for the method when its not needed.