### PR TITLE
Fix Inconsistency with Callback Ordering (#759)

### DIFF
--- a/docs/reference/lifecycle_callbacks.md
+++ b/docs/reference/lifecycle_callbacks.md
@@ -71,7 +71,7 @@ A connected target will later become _disconnected_ when either of the preceding
 * the element's `data-{identifier}-target` attribute is removed or modified
 * the document installs a new `<body>` element, such as during a Turbo page change
 
-When a target becomes disconnected, Stimulus calls its controller's `[name]TargetDisconnected()` method, passing the target element as a parameter. The `[name]TargetDisconnected()` lifecycle callbacks will fire *before* the controller's `disconnect()` callback.
+When a target becomes disconnected, Stimulus calls its controller's `[name]TargetDisconnected()` method, passing the target element as a parameter. The `[name]TargetDisconnected()` lifecycle callbacks will fire *after* the controller's `disconnect()` callback.
 
 ## Reconnection
 

--- a/docs/reference/targets.md
+++ b/docs/reference/targets.md
@@ -95,7 +95,7 @@ removed within the controller's element.
 
 Define a method `[name]TargetConnected` or `[name]TargetDisconnected` in the controller, where `[name]` is the name of the target you want to observe for additions or removals. The method receives the element as the first argument.
 
-Stimulus invokes each element callback any time its target elements are added or removed after `connect()` and before `disconnect()` lifecycle hooks.
+Stimulus invokes each element callback any time its target elements are added or removed. When the controller is connected or disconnected from the document, these callbacks are invoked *before* `connect()` and *after* `disconnect()` lifecycle hooks.
 
 ```js
 export default class extends Controller {
@@ -130,6 +130,6 @@ Always use camelCase to specify target names, since they map directly to propert
 
 ```js
 export default class extends Controller {
-  static targets = [ "camelCase" ]  
+  static targets = [ "camelCase" ]
 }
 ```


### PR DESCRIPTION
This resolves #759 and ensures lifecycle callbacks are documented in the order they happen.
This was validated by simply having the 4 lifecycle callbacks print to console, and having a button to remove the controller element from the document.

![Screenshot 2024-03-19 at 4 16 04 PM](https://github.com/hotwired/stimulus/assets/476/1c5cdb89-c212-4fa5-b471-82900bc1f068)

