### PR TITLE
Fix issue with missing default values

### DIFF
--- a/src/core/value_properties.ts
+++ b/src/core/value_properties.ts
@@ -198,6 +198,19 @@ export function defaultValueForDefinition(typeDefinition: ValueTypeDefinition): 
   return typeDefinition
 }
 
+export function hasCustomDefaultValueForDefinition(typeDefinition: ValueTypeDefinition): boolean {
+  const constant = parseValueTypeConstant(typeDefinition as ValueTypeConstant)
+  if (constant) return false;
+
+  const hasDefault = hasProperty(typeDefinition, "default")
+  if (hasDefault) return true;
+  
+  const hasType = hasProperty(typeDefinition, "type")
+  if (hasType) return false;
+
+  return true;
+}
+
 function valueDescriptorForTokenAndTypeDefinition(payload: ValueTypeDefinitionPayload) {
   const { token, typeDefinition } = payload
 
@@ -211,7 +224,7 @@ function valueDescriptorForTokenAndTypeDefinition(payload: ValueTypeDefinitionPa
       return defaultValueForDefinition(typeDefinition)
     },
     get hasCustomDefaultValue() {
-      return parseValueTypeDefault(typeDefinition) !== undefined
+      return hasCustomDefaultValueForDefinition(typeDefinition)
     },
     reader: readers[type],
     writer: writers[type] || writers.default,

--- a/src/tests/controllers/default_value_controller.ts
+++ b/src/tests/controllers/default_value_controller.ts
@@ -7,23 +7,33 @@ export class DefaultValueController extends Controller {
     defaultBooleanTrue: { type: Boolean, default: true },
     defaultBooleanFalse: { type: Boolean, default: false },
     defaultBooleanOverride: true,
+    defaultBooleanWithTypeConstant: Boolean,
+    defaultBooleanWithTypeProperty: { type: Boolean },
 
     defaultString: "",
     defaultStringHello: { type: String, default: "Hello" },
     defaultStringOverride: "Override me",
+    defaultStringWithTypeConstant: String,
+    defaultStringWithTypeProperty: { type: String },
 
     defaultNumber: 0,
     defaultNumberThousand: { type: Number, default: 1000 },
     defaultNumberZero: { type: Number, default: 0 },
     defaultNumberOverride: 9999,
+    defaultNumberWithTypeConstant: Number,
+    defaultNumberWithTypeProperty: { type: Number },
 
     defaultArray: [],
     defaultArrayFilled: { type: Array, default: [1, 2, 3] },
     defaultArrayOverride: [9, 9, 9],
+    defaultArrayWithTypeConstant: Array,
+    defaultArrayWithTypeProperty: { type: Array },
 
     defaultObject: {},
     defaultObjectPerson: { type: Object, default: { name: "David" } },
     defaultObjectOverride: { override: "me" },
+    defaultObjectWithTypeConstant: Object,
+    defaultObjectWithTypeProperty: { type: Object },
   }
 
   valueDescriptorMap!: ValueDescriptorMap
@@ -36,6 +46,10 @@ export class DefaultValueController extends Controller {
   hasDefaultBooleanFalseValue!: boolean
   defaultBooleanOverrideValue!: boolean
   hasDefaultBooleanOverrideValue!: boolean
+  defaultBooleanWithTypeConstantValue!: boolean
+  hasDefaultBooleanWithTypeConstantValue!: boolean
+  defaultBooleanWithTypePropertyValue!: boolean
+  hasDefaultBooleanWithTypePropertyValue!: boolean
 
   defaultStringValue!: string
   hasDefaultStringValue!: boolean
@@ -43,6 +57,10 @@ export class DefaultValueController extends Controller {
   hasDefaultStringHelloValue!: boolean
   defaultStringOverrideValue!: string
   hasDefaultStringOverrideValue!: boolean
+  defaultStringWithTypeConstantValue!: string
+  hasDefaultStringWithTypeConstantValue!: boolean
+  defaultStringWithTypePropertyValue!: string
+  hasDefaultStringWithTypePropertyValue!: boolean
 
   defaultNumberValue!: number
   hasDefaultNumberValue!: boolean
@@ -52,6 +70,10 @@ export class DefaultValueController extends Controller {
   hasDefaultNumberZeroValue!: boolean
   defaultNumberOverrideValue!: number
   hasDefaultNumberOverrideValue!: boolean
+  defaultNumberWithTypeConstantValue!: number
+  hasDefaultNumberWithTypeConstantValue!: boolean
+  defaultNumberWithTypePropertyValue!: number
+  hasDefaultNumberWithTypePropertyValue!: boolean
 
   defaultArrayValue!: any[]
   hasDefaultArrayValue!: boolean
@@ -59,6 +81,10 @@ export class DefaultValueController extends Controller {
   hasDefaultArrayFilledValue!: boolean
   defaultArrayOverrideValue!: { [key: string]: any }
   hasDefaultArrayOverrideValue!: boolean
+  defaultArrayWithTypeConstantValue!: any[]
+  hasDefaultArrayWithTypeConstantValue!: boolean
+  defaultArrayWithTypePropertyValue!: any[]
+  hasDefaultArrayWithTypePropertyValue!: boolean
 
   defaultObjectValue!: object
   hasDefaultObjectValue!: boolean
@@ -66,6 +92,11 @@ export class DefaultValueController extends Controller {
   hasDefaultObjectPersonValue!: boolean
   defaultObjectOverrideValue!: object
   hasDefaultObjectOverrideValue!: boolean
+  defaultObjectWithTypeConstantValue!: object
+  hasDefaultObjectWithTypeConstantValue!: boolean
+  defaultObjectWithTypePropertyValue!: object
+  hasDefaultObjectWithTypePropertyValue!: boolean
+  
   lifecycleCallbacks: string[] = []
 
   initialize() {

--- a/src/tests/modules/core/default_value_tests.ts
+++ b/src/tests/modules/core/default_value_tests.ts
@@ -46,6 +46,11 @@ export default class DefaultValueTests extends ControllerTestCase(DefaultValueCo
     this.assert.ok(this.controller.hasDefaultBooleanOverrideValue)
   }
 
+  "test boolean with no default value"() {
+    this.assert.notOk(this.controller.hasDefaultBooleanWithTypeConstantValue)
+    this.assert.notOk(this.controller.hasDefaultBooleanWithTypePropertyValue)
+  }
+
   // Strings
 
   "test custom default string values"() {
@@ -74,6 +79,11 @@ export default class DefaultValueTests extends ControllerTestCase(DefaultValueCo
     this.assert.deepEqual(this.get("default-string-override-value"), "I am the expected value")
     this.assert.deepEqual(this.controller.defaultStringOverrideValue, "I am the expected value")
     this.assert.ok(this.controller.hasDefaultStringOverrideValue)
+  }
+
+  "test string with no default value"() {
+    this.assert.notOk(this.controller.hasDefaultStringWithTypeConstantValue)
+    this.assert.notOk(this.controller.hasDefaultStringWithTypePropertyValue)
   }
 
   // Numbers
@@ -110,6 +120,11 @@ export default class DefaultValueTests extends ControllerTestCase(DefaultValueCo
     this.assert.ok(this.controller.hasDefaultNumberOverrideValue)
   }
 
+  "test number with no default value"() {
+    this.assert.notOk(this.controller.hasDefaultNumberWithTypeConstantValue)
+    this.assert.notOk(this.controller.hasDefaultNumberWithTypePropertyValue)
+  }
+
   // Arrays
 
   "test custom default array values"() {
@@ -140,6 +155,11 @@ export default class DefaultValueTests extends ControllerTestCase(DefaultValueCo
     this.assert.ok(this.controller.hasDefaultArrayOverrideValue)
   }
 
+  "test array with no default value"() {
+    this.assert.notOk(this.controller.hasDefaultArrayWithTypeConstantValue)
+    this.assert.notOk(this.controller.hasDefaultArrayWithTypePropertyValue)
+  }
+
   // Objects
 
   "test custom default object values"() {
@@ -168,6 +188,11 @@ export default class DefaultValueTests extends ControllerTestCase(DefaultValueCo
     this.assert.deepEqual(this.get("default-object-override-value"), '{"expected":"value"}')
     this.assert.deepEqual(this.controller.defaultObjectOverrideValue, { expected: "value" })
     this.assert.ok(this.controller.hasDefaultObjectOverrideValue)
+  }
+
+  "test object with no default value"() {
+    this.assert.notOk(this.controller.hasDefaultObjectWithTypeConstantValue)
+    this.assert.notOk(this.controller.hasDefaultObjectWithTypePropertyValue)
   }
 
   "test [name]ValueChanged callbacks fire after initialize and before connect"() {


### PR DESCRIPTION
## Purpose
Resolves issue #772 
https://stimulus.hotwired.dev/reference/values#existential-properties states the following:

> The existential property for a value evaluates to true when the associated data attribute is present on the controller’s element and false when it is absent.

The exception to this defined [here](https://github.com/hotwired/stimulus/blob/e6f1887c9ac91f3d83d8cde0b80c216d0dc3de6e/src/core/value_properties.ts#L55) is when a custom default value is provided. Defaults can be provided either as a literal, or with the `default` property like so: `{ type: String, default: 'abc' }`. 

## Approach
1. If the type is a constant, it does not have a default.
Example: `something: String`
2. If the type has a default property, it does have a default.
Example: `something: { type: String, default: 'abc' }`
3. If the type has a type property (but not a default property), it does not have a default.
Example: `something: { type: String }`
4. Finally, if the type is a literal, it does have a default.
Example: `something: 'abc'`

## Tests
Unit tests with Karma