### PR TITLE
add emphasis to the outlet naming

### DIFF
--- a/docs/reference/outlets.md
+++ b/docs/reference/outlets.md
@@ -33,7 +33,7 @@ While a **target** is a specifically marked element **within the scope** of its 
 
 ## Attributes and Names
 
-The `data-chat-user-status-outlet` attribute is called an _outlet attribute_, and its value is a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) which you can use to refer to other controller elements which should be available as outlets on the _host controller_. The outlet identifier in the host controller must be the same as the target controller's identifier.
+The `data-chat-user-status-outlet` attribute is called an _outlet attribute_, and its value is a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) which you can use to refer to other controller elements which should be available as outlets on the _host controller_. The outlet identifier in the host controller **must be the same** as the target controller's identifier.  If not, it will throw an error message that outlet does not exist. 
 
 ```html
 data-[identifier]-[outlet]-outlet="[selector]"


### PR DESCRIPTION
https://github.com/hotwired/stimulus/issues/669#issuecomment-2782667024

this error is so hard to track down that I added some emphasis and hopefully the search engines will point to this.