### PR TITLE
Fix outlet matching for whitespace-separated data-controller values

### DIFF
--- a/src/core/outlet_set.ts
+++ b/src/core/outlet_set.ts
@@ -66,6 +66,6 @@ export class OutletSet {
 
   private matchesElement(element: Element, selector: string, outletName: string): boolean {
     const controllerAttribute = element.getAttribute(this.scope.schema.controllerAttribute) || ""
-    return element.matches(selector) && controllerAttribute.split(" ").includes(outletName)
+    return element.matches(selector) && controllerAttribute.trim().split(/\s+/).includes(outletName)
   }
 }

--- a/src/tests/modules/core/outlet_tests.ts
+++ b/src/tests/modules/core/outlet_tests.ts
@@ -34,6 +34,13 @@ export default class OutletTests extends ControllerTestCase(OutletController) {
       <div data-controller="namespaced--epsilon" class="epsilon" id="epsilon2"></div>
 
       <div class="beta" id="beta5"></div>
+
+      <div
+        data-controller="
+          beta
+        "
+        id="beta6"
+      ></div>
     </div>
   `
   get identifiers() {
@@ -86,6 +93,12 @@ export default class OutletTests extends ControllerTestCase(OutletController) {
   "test OutletSet#has when selector matches but element doesn't have the right controller"() {
     this.controller.element.setAttribute(`data-${this.identifier}-gamma-outlet`, ".alpha")
     this.assert.equal(this.controller.outlets.has("gamma"), false)
+  }
+
+  "test OutletSet#has when the matched element's data-controller attribute is separated by newlines"() {
+    this.controller.element.setAttribute(`data-${this.identifier}-beta-outlet`, "#beta6")
+    this.assert.equal(this.controller.outlets.has("beta"), true)
+    this.assert.equal(this.controller.outlets.find("beta"), this.findElement("#beta6"))
   }
 
   "test linked outlet properties"() {


### PR DESCRIPTION
`OutletSet#matchesElement` tokenizes the `data-controller` attribute with a naive `.split(" ")`, splitting only on single literal space characters:

```ts
private matchesElement(element: Element, selector: string, outletName: string): boolean {
  const controllerAttribute = element.getAttribute(this.scope.schema.controllerAttribute) || ""
  return element.matches(selector) && controllerAttribute.split(" ").includes(outletName)
}
```

When a `data-controller` value is written across multiple lines, for example, generated by a server-side template that formats the attribute with newlines and indentation for readability, every identifier after the first ends up with a trailing newline glued to it (`"my-controller\n"` instead of `"my-controller"`). `.split(" ")` never removes that newline, so `.includes(outletName)` returns `false` even though the controller is genuinely connected to that element. The result is a "Missing outlet element" error for an outlet that's actually present.

This is inconsistent with how Stimulus parses `data-controller` everywhere else. `TokenListObserver` (responsible for actually connecting controllers) already handles this correctly via `.trim().split(/\s+/)`. This PR applies the same tokenization in `OutletSet#matchesElement` so outlet resolution matches controller-connection semantics.

Also adds a regression test reproducing a `data-controller` value split across multiple lines, verifying the outlet is still found.